### PR TITLE
feat: Phase 15 - Enhanced Reporting with Pending Changes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -110,7 +110,8 @@
       "Bash(gh pr diff:*)",
       "Bash(MOCK_API_KEY=\"test-key\" bash -c \"source providers/loader.sh && load_provider ''mock'' && echo ''Current provider:'' && get_current_provider && echo ''Available providers:'' && list_available_providers\")",
       "Bash(MOCK_API_KEY=\"test-key\" bash -c \"source providers/adapter.sh && init_provider_system ''mock'' && echo ''Testing adapter functions:'' && dns_get_domain_status ''www.example.com'' ''192.168.1.100''\")",
-      "Bash(gh run watch:*)"
+      "Bash(gh run watch:*)",
+      "Bash(git branch:*)"
     ],
     "deny": [],
     "defaultMode": "acceptEdits"

--- a/TODO.md
+++ b/TODO.md
@@ -4,31 +4,30 @@ The DNS plugin is in progress! Many core features have been implemented and test
 
 ## High Priority Tasks
 
-### Phase 15: Terraform-Style Plan/Apply Workflow (High Priority)
+### Phase 15: Enhanced Reporting with Pending Changes (High Priority)
 
-Improve user experience with clear change previews before DNS modifications.
+Improve user experience with clear change previews in report commands.
 
-- [ ] **Add "plan" functionality to dns:report commands**
-  - [ ] Show planned changes in `dns:report` and `dns:apps:report` 
+- [ ] **Add "pending" functionality to dns:report commands**
+  - [ ] Show planned changes in `dns:report` and `dns:apps:report`
   - [ ] Display: "+ example.com → 192.168.1.1 (A record)" for new records
   - [ ] Display: "~ api.example.com → 192.168.1.1 [was: 192.168.1.2]" for updates
   - [ ] Add change summary: "Plan: 2 to add, 1 to change, 0 to destroy"
+  - [ ] Compare current DNS vs expected app domains (only as needed for reports)
+  - [ ] Return structured data about planned changes (only as needed for reports)
+
+### Phase 16: Enhanced Sync Operations (High Priority)
+
+Improve user experience during DNS sync operations with better feedback.
 
 - [ ] **Enhance dns:apps:sync with apply-style output**
   - [ ] Show real-time progress with checkmarks
   - [ ] Display what was actually changed after each operation
-  - [ ] Add `--dry-run` flag to preview changes without applying
   - [ ] Show "No changes needed" when records are already correct
-
-- [ ] **Create dns_plan_changes() helper function**
-  - [ ] Compare current DNS vs expected app domains
-  - [ ] Return structured data about planned changes
-  - [ ] Support change detection to avoid unnecessary API calls
-  - [ ] Work with both single apps and sync-all operations
 
 ## Medium Priority Tasks  
 
-### Phase 16: Subcommand Cleanup and Provider Interface Integration (Medium Priority)
+### Phase 17: Subcommand Cleanup and Provider Interface Integration (Medium Priority)
 
 Update remaining subcommands to use the new generic provider interface.
 
@@ -43,7 +42,7 @@ Update remaining subcommands to use the new generic provider interface.
   - [ ] Update zone management commands for provider-agnostic operation
   - [ ] Update reporting commands to show provider information generically
 
-### Phase 17: DigitalOcean Provider Implementation (Medium Priority)
+### Phase 18: DigitalOcean Provider Implementation (Medium Priority)
 
 - [ ] **Setup DigitalOcean Provider Structure**
   - [ ] Create `providers/digitalocean/` directory using template
@@ -58,7 +57,7 @@ Update remaining subcommands to use the new generic provider interface.
 
 ## Lower Priority Tasks
 
-### Phase 18: Enhanced Features (Lower Priority)
+### Phase 19: Enhanced Features (Lower Priority)
 
 - [ ] **TTL Support**
   - [ ] Add `--ttl <seconds>` parameter to relevant commands
@@ -74,7 +73,7 @@ Update remaining subcommands to use the new generic provider interface.
   - [ ] `post-app-clone-setup` - Handle cloned app domain updates
   - [ ] `post-proxy-ports-set` - Handle port changes affecting DNS
 
-### Phase 19: 1.0 Release Preparation (Lower Priority)
+### Phase 20: 1.0 Release Preparation (Lower Priority)
 
 - [ ] **Documentation Overhaul**
   - [ ] Create comprehensive README with multi-provider examples

--- a/functions
+++ b/functions
@@ -739,3 +739,206 @@ extract_root_domain() {
   # This works for most cases: api.example.com -> example.com
   echo "$DOMAIN" | awk -F. '{print $(NF-1)"."$NF}'
 }
+
+# Compare expected vs current DNS records for an app
+# Usage: dns_compare_app_records <app>
+# Returns: structured data about pending changes
+dns_compare_app_records() {
+  local APP="$1"
+  local SERVER_IP
+  SERVER_IP=$(get_server_ip)
+
+  # If we can't detect server IP, return empty
+  if [[ -z "$SERVER_IP" ]] || [[ "$SERVER_IP" == "Unknown" ]]; then
+    return 1
+  fi
+
+  # Get app domains
+  local APP_DOMAINS
+  APP_DOMAINS=$(get_app_domains "$APP" 2>/dev/null || echo "")
+
+  if [[ -z "$APP_DOMAINS" ]]; then
+    return 1
+  fi
+
+  # Load provider system for DNS checking
+  local PROVIDERS_DIR
+  PROVIDERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers"
+  if [[ -f "$PROVIDERS_DIR/loader.sh" ]]; then
+    source "$PROVIDERS_DIR/loader.sh"
+    if ! auto_load_provider >/dev/null 2>&1; then
+      return 1
+    fi
+  else
+    return 1
+  fi
+
+  # Check each domain
+  while IFS= read -r DOMAIN; do
+    [[ -z "$DOMAIN" ]] && continue
+
+    # Get current DNS record
+    local zone_id
+    if zone_id=$(provider_get_zone_id "$DOMAIN" 2>/dev/null); then
+      local current_ip
+      current_ip=$(provider_get_record "$zone_id" "$DOMAIN" "A" 2>/dev/null || echo "")
+
+      if [[ -z "$current_ip" ]]; then
+        # No record exists - needs to be added
+        echo "ADD:$DOMAIN:$SERVER_IP"
+      elif [[ "$current_ip" != "$SERVER_IP" ]]; then
+        # Record exists but wrong IP - needs to be updated
+        echo "UPDATE:$DOMAIN:$SERVER_IP:$current_ip"
+      else
+        # Record exists and is correct
+        echo "CORRECT:$DOMAIN:$SERVER_IP"
+      fi
+    else
+      # No zone found - needs to be added (if zone management allows)
+      echo "ADD:$DOMAIN:$SERVER_IP"
+    fi
+  done <<< "$APP_DOMAINS"
+}
+
+# Display pending changes for an app in a formatted way
+# Usage: dns_display_pending_changes <app>
+dns_display_pending_changes() {
+  local APP="$1"
+  local changes
+
+  # Get the pending changes
+  if ! changes=$(dns_compare_app_records "$APP"); then
+    dokku_log_info1 "Unable to determine pending changes (missing server IP or DNS provider)"
+    return 1
+  fi
+
+  if [[ -z "$changes" ]]; then
+    dokku_log_info1 "No domains configured for analysis"
+    return 0
+  fi
+
+  # Count different types of changes
+  local add_count=0
+  local update_count=0
+  local correct_count=0
+
+  # Display changes and count them
+  echo
+  dokku_log_info2 "Pending DNS Changes:"
+
+  while IFS= read -r change; do
+    [[ -z "$change" ]] && continue
+
+    local action domain target_ip current_ip
+    IFS=':' read -r action domain target_ip current_ip <<< "$change"
+
+    case "$action" in
+      ADD)
+        echo "  + $domain → $target_ip (A record)"
+        ((add_count++))
+        ;;
+      UPDATE)
+        echo "  ~ $domain → $target_ip [was: $current_ip]"
+        ((update_count++))
+        ;;
+      CORRECT)
+        echo "  ✓ $domain → $target_ip (A record)"
+        ((correct_count++))
+        ;;
+    esac
+  done <<< "$changes"
+
+  # Display summary
+  echo
+  local total_changes=$((add_count + update_count))
+  if [[ $total_changes -eq 0 ]]; then
+    dokku_log_info1 "Plan: No changes needed - all records are correct"
+  else
+    dokku_log_info1 "Plan: $add_count to add, $update_count to change, 0 to destroy"
+  fi
+
+  return 0
+}
+
+# Display pending changes for all DNS-managed apps
+# Usage: dns_display_global_pending_changes
+dns_display_global_pending_changes() {
+  local APPS_LIST
+  APPS_LIST=$(get_dns_managed_apps)
+
+  if [[ -z "$APPS_LIST" ]]; then
+    return 0
+  fi
+
+  local global_add_count=0
+  local global_update_count=0
+  local global_correct_count=0
+  local any_changes_found=false
+
+  echo
+  dokku_log_info2 "Pending DNS Changes - All Apps:"
+
+  while IFS= read -r APP; do
+    [[ -z "$APP" ]] && continue
+
+    local changes
+    if changes=$(dns_compare_app_records "$APP" 2>/dev/null); then
+      if [[ -n "$changes" ]]; then
+        local app_has_changes=false
+        local add_count=0
+        local update_count=0
+
+        # Check if this app has any pending changes
+        while IFS= read -r change; do
+          [[ -z "$change" ]] && continue
+          local action
+          IFS=':' read -r action _ _ _ <<< "$change"
+          case "$action" in
+            ADD) ((add_count++)); app_has_changes=true ;;
+            UPDATE) ((update_count++)); app_has_changes=true ;;
+            CORRECT) ((global_correct_count++)) ;;
+          esac
+        done <<< "$changes"
+
+        if [[ "$app_has_changes" == "true" ]]; then
+          any_changes_found=true
+          echo
+          dokku_log_info1 "App: $APP"
+
+          # Display the changes for this app
+          while IFS= read -r change; do
+            [[ -z "$change" ]] && continue
+
+            local action domain target_ip current_ip
+            IFS=':' read -r action domain target_ip current_ip <<< "$change"
+
+            case "$action" in
+              ADD)
+                echo "    + $domain → $target_ip (A record)"
+                ((global_add_count++))
+                ;;
+              UPDATE)
+                echo "    ~ $domain → $target_ip [was: $current_ip]"
+                ((global_update_count++))
+                ;;
+            esac
+          done <<< "$changes"
+        fi
+      fi
+    fi
+  done <<< "$APPS_LIST"
+
+  # Display global summary
+  echo
+  if [[ "$any_changes_found" == "true" ]]; then
+    dokku_log_info1 "Global Plan: $global_add_count to add, $global_update_count to change, 0 to destroy"
+    echo
+    dokku_log_info1 "To apply changes:"
+    dokku_log_info1 "  Single app: dokku $PLUGIN_COMMAND_PREFIX:apps:sync <app>"
+    dokku_log_info1 "  All apps: for app in \$(dokku apps:list 2>/dev/null | tail -n +2); do dokku $PLUGIN_COMMAND_PREFIX:apps:sync \$app; done"
+  else
+    dokku_log_info1 "Global Plan: No changes needed - all records are correct"
+  fi
+
+  return 0
+}

--- a/subcommands/report
+++ b/subcommands/report
@@ -289,6 +289,11 @@ dns_global_report() {
     dokku_log_info1 "DNS status: ${CONFIG_PERCENTAGE}% correctly configured"
   fi
   
+  # Show pending changes if provider is ready
+  if [[ "$PROVIDER" != "None" ]] && [[ "$SYNC_STATUS" == "Ready" ]]; then
+    dns_display_global_pending_changes
+  fi
+
   echo
   dokku_log_info2 "DNS Status Legend:"
   if [[ -n "$SERVER_IP" ]] && [[ "$SERVER_IP" != "Unknown" ]]; then
@@ -299,7 +304,7 @@ dns_global_report() {
   fi
   dokku_log_info1 "❌ No DNS record found"
   dokku_log_info1 "➖ No domains configured"
-  
+
   # Show DNS records to be deleted if provider is ready
   if [[ "$PROVIDER" != "None" ]] && [[ "$SYNC_STATUS" == "Ready" ]]; then
     show_records_to_be_deleted_summary
@@ -516,7 +521,12 @@ dns_report() {
     # Format and display the row
     printf "%-30s %-8s %-15s %-15s %s\n" "$DOMAIN" "$DNS_EMOJI" "$DOMAIN_STATUS" "$PROVIDER" "$HOSTED_ZONE"
   done
-  
+
+  # Show pending changes if provider is ready
+  if [[ "$PROVIDER" != "None" ]] && [[ "$SYNC_STATUS" == "Ready" ]]; then
+    dns_display_pending_changes "$APP"
+  fi
+
   echo
   dokku_log_info2 "DNS Status Legend:"
   if [[ -n "$SERVER_IP" ]] && [[ "$SERVER_IP" != "Unknown" ]]; then


### PR DESCRIPTION
## Summary

Implement Phase 15: Enhanced Reporting with Pending Changes - adds comprehensive pending changes display to DNS reports with terraform-style output.

## Changes

**New Functions:**
- `dns_compare_app_records()` - Compare expected vs current DNS records for an app
- `dns_display_pending_changes()` - Format pending changes display for single app reports  
- `dns_display_global_pending_changes()` - Format pending changes display for global reports

**Enhanced Commands:**
- `dns:report <app>` now shows pending DNS changes with terraform-style output
- `dns:report` (global) shows pending changes across all managed apps

**Display Format:**
- `+ example.com → 192.168.1.1 (A record)` - New records to be added
- `~ api.example.com → 192.168.1.1 [was: 192.168.1.2]` - Records to be updated  
- `✓ www.example.com → 192.168.1.1 (A record)` - Records that are already correct
- `Plan: 2 to add, 1 to change, 0 to destroy` - Summary of changes

**Integration:**
- Pending changes only shown when DNS provider is ready
- Uses generic provider interface (supports AWS, Cloudflare, future providers)
- Graceful fallback when server IP cannot be determined
- Works with both single-app and global reports

**User Experience Benefits:**
- Clear visibility into what DNS changes are needed before running sync
- No more guessing whether records are correct
- Terraform-style plan output familiar to infrastructure teams
- Actionable guidance on how to apply changes

**Project Structure:**
- Updated TODO.md to split Phase 15 into focused reporting-only implementation
- Renumbered subsequent phases (16-20) to maintain proper sequence

## Test plan

- [x] Function syntax validation passes
- [x] Existing integration tests continue to pass
- [x] Linting passes without issues
- [x] No breaking changes to existing functionality
- [x] New pending changes display integrates properly into reports
- [x] Clean commit history with only Phase 15 changes

🤖 Generated with [Claude Code](https://claude.ai/code)