### PR TITLE
Phase 23: Dependency Management & Installation Improvements

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# DNS plugin dependencies installer
+# Follows https://dokku.com/docs/development/plugin-creation/#verify-the-existence-of-dependencies
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+# Install jq if missing (required by all DNS providers)
+if ! command -v jq &>/dev/null; then
+  echo "-----> Installing jq dependency for DNS plugin"
+
+  # Try to install jq using available package managers
+  if command -v apt-get &>/dev/null; then
+    # Ubuntu/Debian
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update &>/dev/null
+    apt-get install -qq -y jq &>/dev/null
+  elif command -v yum &>/dev/null; then
+    # CentOS/RHEL (older)
+    yum install -y jq &>/dev/null
+  elif command -v dnf &>/dev/null; then
+    # CentOS/RHEL/Fedora (newer)
+    dnf install -y jq &>/dev/null
+  elif command -v apk &>/dev/null; then
+    # Alpine Linux
+    apk add --no-cache jq &>/dev/null
+  elif command -v brew &>/dev/null; then
+    # macOS with Homebrew
+    brew install jq &>/dev/null
+  else
+    echo "       Unable to automatically install jq."
+    echo "       Please install jq manually: https://stedolan.github.io/jq/download/"
+    exit 1
+  fi
+
+  # Verify installation
+  if command -v jq &>/dev/null; then
+    echo "       ✓ jq installed successfully ($(jq --version))"
+  else
+    echo "       ✗ jq installation failed"
+    exit 1
+  fi
+else
+  echo "       ✓ jq already available ($(jq --version))"
+fi

--- a/dependencies
+++ b/dependencies
@@ -13,32 +13,53 @@ if ! command -v jq &>/dev/null; then
   # Try to install jq using available package managers
   if command -v apt-get &>/dev/null; then
     # Ubuntu/Debian
+    echo "       Installing jq via apt-get..."
     export DEBIAN_FRONTEND=noninteractive
-    apt-get update &>/dev/null
-    apt-get install -qq -y jq &>/dev/null
+    if apt-get update >/dev/null 2>&1 && apt-get install -qq -y jq >/dev/null 2>&1; then
+      echo "       ✓ jq installed successfully via apt-get"
+    else
+      echo "       ✗ Failed to install jq via apt-get"
+      exit 1
+    fi
   elif command -v yum &>/dev/null; then
     # CentOS/RHEL (older)
-    yum install -y jq &>/dev/null
+    echo "       Installing jq via yum..."
+    if yum install -y jq >/dev/null 2>&1; then
+      echo "       ✓ jq installed successfully via yum"
+    else
+      echo "       ✗ Failed to install jq via yum"
+      exit 1
+    fi
   elif command -v dnf &>/dev/null; then
     # CentOS/RHEL/Fedora (newer)
-    dnf install -y jq &>/dev/null
+    echo "       Installing jq via dnf..."
+    if dnf install -y jq >/dev/null 2>&1; then
+      echo "       ✓ jq installed successfully via dnf"
+    else
+      echo "       ✗ Failed to install jq via dnf"
+      exit 1
+    fi
   elif command -v apk &>/dev/null; then
     # Alpine Linux
-    apk add --no-cache jq &>/dev/null
+    echo "       Installing jq via apk..."
+    if apk add --no-cache jq >/dev/null 2>&1; then
+      echo "       ✓ jq installed successfully via apk"
+    else
+      echo "       ✗ Failed to install jq via apk"
+      exit 1
+    fi
   elif command -v brew &>/dev/null; then
     # macOS with Homebrew
-    brew install jq &>/dev/null
+    echo "       Installing jq via brew..."
+    if brew install jq >/dev/null 2>&1; then
+      echo "       ✓ jq installed successfully via brew"
+    else
+      echo "       ✗ Failed to install jq via brew"
+      exit 1
+    fi
   else
     echo "       Unable to automatically install jq."
     echo "       Please install jq manually: https://stedolan.github.io/jq/download/"
-    exit 1
-  fi
-
-  # Verify installation
-  if command -v jq &>/dev/null; then
-    echo "       ✓ jq installed successfully ($(jq --version))"
-  else
-    echo "       ✗ jq installation failed"
     exit 1
   fi
 else

--- a/install
+++ b/install
@@ -18,6 +18,27 @@ if ! declare -f fn-plugin-property-setup >/dev/null 2>&1; then
   }
 fi
 
+check_dependencies() {
+  # Check for jq (required by all providers) following Dokku guidelines
+  if ! command -v jq &>/dev/null; then
+    echo "       ⚠ Missing jq, install it"
+    echo ""
+    echo "jq is required for JSON processing by all DNS providers."
+    echo ""
+    echo "Install jq using your system's package manager:"
+    echo "  Ubuntu/Debian:    sudo apt-get install jq"
+    echo "  CentOS/RHEL:      sudo yum install jq"
+    echo "  macOS (Homebrew): brew install jq"
+    echo ""
+    echo "Or download from: https://stedolan.github.io/jq/download/"
+    return 1
+  else
+    echo "       ✓ jq found (required for JSON processing)"
+  fi
+
+  return 0
+}
+
 detect_and_configure_provider() {
   local PROVIDER_FILE="$PLUGIN_DATA_ROOT/PROVIDER"
   local DETECTED_PROVIDERS=()
@@ -80,6 +101,13 @@ detect_and_configure_provider() {
 
 plugin-install() {
   echo "-----> Installing $PLUGIN_SERVICE plugin"
+
+  # Check dependencies first
+  echo "-----> Checking dependencies..."
+  if ! check_dependencies; then
+    echo "-----> Dependency check failed. Please install missing dependencies and retry."
+    exit 1
+  fi
 
   # Set up plugin properties
   fn-plugin-property-setup "$PLUGIN_COMMAND_PREFIX"

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,4 +1,9 @@
 [plugin]
-description = "DNS management plugin for Dokku with multi-cloud provider support (AWS Route53, Cloudflare)"
+description = "DNS management plugin for Dokku with multi-cloud provider support (AWS Route53, Cloudflare, DigitalOcean)"
 version = "0.3.0"
+
+[plugin.dependencies]
+# Required system dependencies
+jq = "JSON processor for provider API responses"
+
 [plugin.config]

--- a/providers/aws/README.md
+++ b/providers/aws/README.md
@@ -13,20 +13,23 @@ This provider integrates with Amazon Web Services (AWS) Route53 to manage DNS re
 
 ## Setup
 
-### 1. Install AWS CLI
+### 1. Install Dependencies
 
-Install the AWS CLI v2:
+The AWS provider requires both AWS CLI v2 and jq:
 
 ```bash
 # On macOS (Homebrew)
-brew install awscli
+brew install awscli jq
 
 # On Ubuntu/Debian
 sudo apt-get update
-sudo apt-get install awscli
+sudo apt-get install awscli jq
 
 # On Amazon Linux
-sudo yum install awscli
+sudo yum install awscli jq
+
+# On CentOS/RHEL/Rocky Linux
+sudo dnf install awscli jq
 ```
 
 ### 2. Configure AWS Credentials

--- a/subcommands/providers:verify
+++ b/subcommands/providers:verify
@@ -39,7 +39,28 @@ service-providers-verify-cmd() {
   
   local PROVIDER_ARG="$1"
   local GLOBAL_CONFIG_ROOT="$PLUGIN_DATA_ROOT"
-  
+
+  # Check dependencies first
+  dokku_log_info2 "Checking Dependencies"
+
+  # Check jq following Dokku guidelines
+  if ! command -v jq &>/dev/null; then
+    dokku_log_fail "Missing jq, install it
+
+jq is required for JSON processing by all DNS providers.
+
+Install jq:
+  Ubuntu/Debian:    sudo apt-get install jq
+  CentOS/RHEL:      sudo yum install jq
+  macOS (Homebrew): brew install jq
+
+Or download from: https://stedolan.github.io/jq/download/"
+  else
+    dokku_log_info1 "  jq: available ($(jq --version))"
+  fi
+
+  echo
+
   # Always verify AWS (the only supported provider)
   local PROVIDER="aws"
   dokku_log_info2 "Verifying AWS Route53 provider"


### PR DESCRIPTION
## Summary

This PR implements Phase 23 from our roadmap: comprehensive dependency management and installation improvements that standardize jq usage across all providers and add robust dependency checking following Dokku's official guidelines.

### 🔧 Standardized jq Usage Across All Providers

**AWS Provider Modernization:**
- Migrated from AWS CLI `--query` expressions to consistent jq usage
- Added `_check_aws_response()` helper function following Cloudflare/DigitalOcean patterns
- Updated `provider_list_zones()` to use jq for JSON processing
- Enhanced `provider_get_zone_id()` with jq-based zone lookup
- Improved `provider_get_record()` with better error handling
- Simplified `provider_delete_record()` JSON processing
- Added jq dependency validation to `provider_validate_credentials()`

**Consistency Benefits:**
- All providers now use identical JSON processing patterns
- Unified error handling and fallback value capabilities
- Simplified debugging with consistent jq expressions
- Better maintainability across provider implementations

### 📦 Comprehensive Dependency Management

**Following Dokku Guidelines:**
- Added `dependencies` hook for automatic jq installation
- Enhanced `install` script with dependency checking using `command -v` pattern
- Updated `providers:verify` command with dependency validation
- Used `dokku_log_fail` for consistent error messaging
- Provided platform-specific installation instructions

**Installation Improvements:**
- **Auto-detection**: Automatic jq installation on Ubuntu/Debian, CentOS/RHEL, Alpine, macOS
- **Clear Messaging**: Helpful error messages when dependencies are missing
- **Plugin Metadata**: Declared jq dependency in plugin.toml
- **Health Checks**: Dependency verification in provider setup

### 🎯 Technical Improvements

**AWS Provider Examples:**
```bash
# Before (AWS CLI query)
aws route53 list-hosted-zones --query 'HostedZones[].Name' --output text

# After (consistent jq)
aws route53 list-hosted-zones --output json | jq -r '.HostedZones[]?.Name // empty'
```

**Error Handling:**
```bash
# New structured error checking
if ! _check_aws_response "$response" "zone listing"; then
  return 1
fi
```

**Dependency Management:**
```bash
# Dokku-compliant dependency checking
if ! command -v jq &>/dev/null; then
  dokku_log_fail "Missing jq, install it"
fi
```

### 📊 Impact

**Developer Experience:**
- Consistent patterns across all providers reduce cognitive load
- Better error messages help users resolve issues quickly
- Automatic dependency installation eliminates manual setup steps

**Code Quality:**
- Unified JSON processing reduces code duplication
- Structured error handling improves reliability
- Following Dokku guidelines ensures compatibility

**User Experience:**
- Clear installation guidance for all platforms
- Automatic dependency resolution when possible
- Helpful error messages with specific installation instructions

### ✅ Dokku Compliance

This implementation follows the official Dokku plugin development guidelines:
- Uses `command -v` for dependency checking
- Implements `dependencies` hook for automatic installation
- Uses `dokku_log_fail` for error messaging
- Provides clear installation instructions
- Follows recommended error handling patterns

Reference: https://dokku.com/docs/development/plugin-creation/#verify-the-existence-of-dependencies

## Test Plan

- [x] All existing provider tests pass
- [x] AWS provider loads correctly with jq patterns
- [x] Dependency checking works in install script
- [x] Dependencies hook automatically installs jq
- [x] Providers:verify command validates dependencies
- [x] Shellcheck linting passes
- [x] Pre-commit hooks pass

## Files Changed

- `dependencies` - New automatic dependency installer
- `install` - Enhanced with dependency checking
- `plugin.toml` - Declared jq dependency
- `providers/aws/provider.sh` - Migrated to jq usage
- `providers/aws/README.md` - Updated dependency documentation
- `subcommands/providers:verify` - Added dependency validation

🤖 Generated with [Claude Code](https://claude.ai/code)