### PR TITLE
Phase 26: Fix Test Output Issues and Add Code Review Phases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,85 @@ The DNS plugin is in progress! Many core features have been implemented and test
 
 
 
-### Phase 26: Pre-Release Testing & Validation
+### Phase 26: Fix Test Output Issues (Critical - Pre-Release)
+
+See `test-output-examples/` folder for actual command outputs showing these issues.
+
+- [ ] **Fix provider-verify-output.txt Issues**
+  - [ ] Reduce excessive verbosity (multiple heading levels, redundant messages)
+  - [ ] Condense zone listing (don't show every zone detail in table)
+  - [ ] Remove redundant "checking" messages
+  - [ ] Show summary counts instead of full credential detection lists
+  - [ ] Add --verbose flag for detailed output if needed
+
+- [ ] **Fix apps-enable.txt Issues**
+  - [ ] Fix contradictory "zone enabled" vs "No (no hosted zone)" messages
+  - [ ] Ensure status indicators (✅/❌) match actual enablement state
+  - [ ] Remove confusing "Provider" column showing "AWS" when zones aren't enabled
+  - [ ] Clarify difference between "zone exists" vs "zone enabled for auto-discovery"
+  - [ ] Fix Domain Status Table showing wrong information
+
+- [ ] **Fix no-zones-found.txt Issues**
+  - [ ] apps:sync fails with "No hosted zone found" despite zone being enabled
+  - [ ] Zone lookup logic broken in sync operation
+  - [ ] Ensure sync uses same zone detection as apps:enable
+  - [ ] Test: recipes.deanoftech.com should find deanoftech.com zone (Z0444961AB4Z3I5DF5NH)
+
+- [ ] **Fix app-create-trigger-fail.txt Issues**
+  - [ ] post-create trigger says "No domains configured" but domain exists
+  - [ ] Trigger doesn't detect auto-added domain from global vhost
+  - [ ] Fix is_domain_in_enabled_zone function or post-create timing
+  - [ ] Test: my-test-app.deanoftech.com should be detected in enabled deanoftech.com zone
+
+
+### Phase 27: Code Quality - Critical Fixes (Pre-Release)
+
+- [ ] **Fix Installation Issues**
+  - [ ] Remove "default DNS provider" concept from install script
+  - [ ] Update install script to detect DigitalOcean credentials/CLI
+  - [ ] Install should report multi-provider mode when multiple providers detected
+  - [ ] Remove PROVIDER file creation (deprecated in favor of multi-provider)
+
+- [ ] **Improve Zone Enable Output**
+  - [ ] Output copy-pastable commands when enabling a zone
+  - [ ] Show `dokku dns:apps:enable <app>` commands with domain as comment
+  - [ ] Format: `dokku dns:apps:enable myapp  # example.com`
+  - [ ] Group by app to avoid duplicate commands
+
+- [ ] **Update Install Script Next Steps**
+  - [ ] Change "Set up AWS credentials" to "Verify provider setup" with [provider] parameter
+  - [ ] Add "Enable DNS zones" as step 2 before app management
+  - [ ] Update steps to: verify → zones → apps → sync (zone-centric workflow)
+  - [ ] Make provider-agnostic (not AWS-specific)
+
+- [ ] **Add Triggers to Getting Started**
+  - [ ] Show `dokku dns:triggers:enable` in installation next steps
+  - [ ] Add to README Quick Start guide after zone enablement
+  - [ ] Explain that triggers enable automatic DNS management on domain changes
+
+- [ ] **Add Missing zones:sync Command**
+  - [ ] Create `dns:zones:sync [zone]` subcommand
+  - [ ] Sync all apps/domains within a specific zone
+  - [ ] If zone parameter omitted, sync all enabled zones
+  - [ ] Show progress per domain within the zone
+
+- [ ] **Fix Linting Failures**
+  - [ ] Remove unused `dokku_log_fail` function in commands file (line 13)
+  - [ ] Add shellcheck disable directive if function is intentionally unused for fallback
+
+- [ ] **Fix Unsafe Error Handling Patterns**
+  - [ ] Replace `set +e`/`set -e` patterns in functions:405-408 with subshells
+  - [ ] Replace `set +e`/`set -e` patterns in functions:992-994 with command substitution
+  - [ ] Replace `set +e`/`set -e` patterns in functions:1006-1008 with if-blocks
+  - [ ] Replace `set +e`/`set -e` patterns in functions:1045-1047 with proper error handling
+
+- [ ] **Add Safety to Destructive Operations**
+  - [ ] Add explicit validation before rm -rf in post-domains-update:133
+  - [ ] Verify APP variable is not empty, not "/", and directory exists before deletion
+  - [ ] Add similar validation to any other rm -rf operations in codebase
+
+
+### Phase 29: Pre-Release Testing & Validation
 
 - [ ] **Create Testing Documentation**
   - [ ] Create TESTING.md with manual test procedures for all providers
@@ -29,7 +107,7 @@ The DNS plugin is in progress! Many core features have been implemented and test
   - [ ] Test sync-all command with multiple apps and providers
 
 
-### Phase 27: 1.0 Release
+### Phase 30: 1.0 Release
 
 - [ ] **GitHub Release Infrastructure**
   - [ ] Create semantic version tagging strategy (v1.0.0)
@@ -47,7 +125,7 @@ The DNS plugin is in progress! Many core features have been implemented and test
   - [ ] Set up performance monitoring and error tracking
 
 
-### Phase 28: Community & Support
+### Phase 31: Community & Support (Post-Release)
 
 - [ ] **Community Announcements**
   - [ ] Post to Dokku community forum
@@ -66,6 +144,144 @@ The DNS plugin is in progress! Many core features have been implemented and test
   - [ ] Set up community feedback collection and analysis process
   - [ ] Create bug triage and priority classification system
   - [ ] Design feature request evaluation and roadmap integration
+
+
+### Phase 32: Code Quality - Medium Priority Cleanup (Post-1.0)
+
+- [ ] **Extract Duplicate Provider Code**
+  - [ ] Create `apply_dns_record` helper function in adapter.sh
+  - [ ] Replace duplicated code in adapter.sh:204-210 and 221-227
+  - [ ] Ensure error messages are preserved (not sent to /dev/null)
+  - [ ] Add proper error logging for debugging
+
+- [ ] **Add Comprehensive Input Validation**
+  - [ ] Create `validate_dns_domain` helper function for RFC 1035 compliance
+  - [ ] Add domain validation to all subcommands that accept domains
+  - [ ] Add TTL validation to zones:ttl subcommand (currently missing)
+  - [ ] Add TTL validation to ttl subcommand (currently missing)
+  - [ ] Ensure consistent validation across all entry points
+
+- [ ] **Define Constants in Config**
+  - [ ] Add DNS_DEFAULT_TTL=300 to config file
+  - [ ] Add DNS_MIN_TTL=60 to config file
+  - [ ] Add DNS_MAX_TTL=86400 to config file
+  - [ ] Replace hardcoded "300" in functions:981 with constant
+  - [ ] Replace hardcoded TTL values in adapter.sh:202, 218 with constants
+  - [ ] Update all TTL validation to use constants
+
+
+### Phase 28: Code Quality - High Priority Refactoring (Pre-Release)
+
+- [ ] **Create Testing Documentation**
+  - [ ] Create TESTING.md with manual test procedures for all providers
+  - [ ] Document CRUD operations test checklist for AWS Route53
+  - [ ] Document CRUD operations test checklist for Cloudflare
+  - [ ] Document CRUD operations test checklist for DigitalOcean
+  - [ ] Include test result logging template with pass/fail criteria
+  - [ ] Document common troubleshooting scenarios and solutions
+
+- [ ] **Provider Integration Testing**
+  - [ ] Execute AWS Route53 CRUD operations on production server
+  - [ ] Execute Cloudflare CRUD operations on production server
+  - [ ] Execute DigitalOcean CRUD operations on production server
+  - [ ] Test multi-provider zone routing (domains in different providers)
+  - [ ] Validate provider failover and error handling
+
+- [ ] **Installation & Deployment Testing**
+  - [ ] Test plugin installation from GitHub on fresh Dokku instance
+  - [ ] Validate provider setup workflow for each provider
+  - [ ] Test automatic zone discovery after provider configuration
+  - [ ] Verify trigger system integration with app lifecycle events
+  - [ ] Test sync-all command with multiple apps and providers
+
+
+### Phase 29: 1.0 Release
+
+- [ ] **GitHub Release Infrastructure**
+  - [ ] Create semantic version tagging strategy (v1.0.0)
+  - [ ] Set up release branch protection and approval workflows
+
+- [ ] **Release Artifacts**
+  - [ ] Generate documentation bundle with all guides and references
+  - [ ] Create installation scripts for multiple platforms
+
+- [ ] **Post-Release Validation**
+  - [ ] Verify GitHub release visibility and downloads
+  - [ ] Validate documentation link accessibility
+  - [ ] Coordinate community notifications and announcements
+  - [ ] Prepare issue tracking and support channels
+  - [ ] Set up performance monitoring and error tracking
+
+
+### Phase 30: Community & Support (Post-Release)
+
+- [ ] **Community Announcements**
+  - [ ] Post to Dokku community forum
+  - [ ] Create GitHub repository announcement and pinned issue
+  - [ ] Execute social media announcement strategy
+  - [ ] Publish technical blog post highlighting key features
+
+- [ ] **Support Infrastructure**
+  - [ ] Create issue templates for bug reports and feature requests
+  - [ ] Create discussion templates for community support
+  - [ ] Write contributing guidelines for community contributors
+  - [ ] Establish code of conduct and community standards
+
+- [ ] **Post-Release Maintenance Planning**
+  - [ ] Define patch release strategy and versioning scheme
+  - [ ] Set up community feedback collection and analysis process
+  - [ ] Create bug triage and priority classification system
+  - [ ] Design feature request evaluation and roadmap integration
+
+
+### Phase 33: Code Quality - Low Priority Polish (Post-1.0)
+
+- [ ] **Reduce Logging Verbosity**
+  - [ ] Extract logging from functions:347-397 (dns_add_app_domains)
+  - [ ] Create `log_domain_check` helper for conditional verbose logging
+  - [ ] Add DNS_VERBOSE environment variable support
+  - [ ] Reduce function to <80 lines by extracting logging
+
+- [ ] **Create Common Functions File**
+  - [ ] Create new `common-functions` file with standard fallback functions
+  - [ ] Move dokku_log_info1, dokku_log_info2, dokku_log_warn, dokku_log_fail definitions
+  - [ ] Update all files to source common-functions instead of duplicating
+  - [ ] Remove duplicate function definitions from 10+ files (commands, subcommands, hooks)
+
+- [ ] **Simplify Complex Conditionals**
+  - [ ] Refactor functions:363-397 to use early returns
+  - [ ] Extract validation logic to separate functions
+  - [ ] Create `handle_no_provider_validation` helper
+  - [ ] Create `validate_domains_with_provider` helper
+  - [ ] Reduce nesting depth in complex conditionals
+
+- [ ] **Standardize Quoting**
+  - [ ] Audit all variable references for missing quotes
+  - [ ] Ensure all `$var` become `"$var"`
+  - [ ] Ensure all `${array[@]}` become `"${array[@]}"`
+  - [ ] Add linting rule to enforce proper quoting
+
+
+
+- [ ] **Improve Documentation**
+  - [ ] Add detailed comments to providers/aws/provider.sh:8-28
+  - [ ] Document complex regex patterns and jq operations
+  - [ ] Add function-level documentation for internal helpers
+  - [ ] Document expected inputs, outputs, and side effects
+
+- [ ] **Standardize Function Naming**
+  - [ ] Create naming convention guide
+  - [ ] Public API: `dns_*`
+  - [ ] Internal helpers: `_dns_*` (underscore prefix)
+  - [ ] Predicates: `is_*` or `has_*`
+  - [ ] Getters: `get_*`, Setters: `set_*`
+  - [ ] Refactor inconsistent function names across codebase
+
+- [ ] **Add ShellCheck Directives**
+  - [ ] Audit all shellcheck warnings
+  - [ ] Add explicit `# shellcheck disable=SCXXXX` where needed
+  - [ ] Add explanatory comments for each disable directive
+  - [ ] Document why each check is disabled
 
 
 ## Future Enhancements

--- a/test-output-examples/app-create-trigger-fail.txt
+++ b/test-output-examples/app-create-trigger-fail.txt
@@ -1,0 +1,12 @@
+~$ dokku apps:create my-test-app
+-----> Creating my-test-app...
+-----> DNS: Checking if app 'my-test-app' should be added to DNS management...
+-----> DNS: No domains configured for 'my-test-app' yet. DNS will be available when domains are added.
+-----> Creating new app virtual host file...
+~$ dokku domains:report my-test-app
+=====> my-test-app domains information
+       Domains app enabled:           true
+       Domains app vhosts:            my-test-app.deanoftech.com
+       Domains global enabled:        true
+       Domains global vhosts:         deanoftech.com
+~$

--- a/test-output-examples/apps-enable.txt
+++ b/test-output-examples/apps-enable.txt
@@ -1,0 +1,27 @@
+$ dokku dns:apps:enable recipes
+-----> Adding all domains for app 'recipes':
+----->   • recipes.deanoftech.com
+-----> Processing 1 new domain(s) for app 'recipes':
+----->   • recipes.deanoftech.com
+
+-----> Filtering domains - Using provider system, New domains: 1
+-----> Provider system ready - checking zones for new domains...
+-----> Checking domain: recipes.deanoftech.com
+-----> ✓ recipes.deanoftech.com can be managed (zone enabled)
+-----> Finished checking domain: recipes.deanoftech.com
+-----> Completed zone checks for all domains
+
+
+=====> Domain Status Table for app 'recipes':
+Domain                         Status   Enabled         Provider        Zone (Enabled)
+------                         ------   -------         --------        ---------------
+recipes.deanoftech.com         ✅      No (no hosted zone) AWS             Not found
+
+=====> Status Legend:
+-----> ✅ Points to server IP (68.55.81.191)
+-----> ⚠️  Points to different IP
+-----> ❌ No DNS record found
+=====> Adding domains for app 'recipes' to DNS (1 domains)
+-----> App 'recipes' added to DNS
+-----> 1 domain(s) with hosted zones have been added to DNS
+-----> Next step: dokku dns:apps:sync recipes

--- a/test-output-examples/no-zones-found.txt
+++ b/test-output-examples/no-zones-found.txt
@@ -1,0 +1,39 @@
+$ dokku dns:apps:sync recipes
+Syncing domains for app 'recipes' to server IP: 68.55.81.191
+
+Analyzing current DNS records...
+  Checking recipes.deanoftech.com... ❌ No hosted zone found
+
+No changes needed! All DNS records are already correct.
+~$ dokku dns:zones deanoftech.com
+
+=====> DNS Zone Details: deanoftech.com
+
+=====> Dokku Integration
+-----> Managed Domains: 1
+  - recipes.deanoftech.com (app: recipes)
+
+=====> Potential Dokku Domains
+-----> Unmanaged domains that could be added:
+  • ddclient.deanoftech.com (app: ddclient)
+  • dean-is.deanoftech.com (app: dean-is)
+  • headless-chrome.deanoftech.com (app: headless-chrome)
+  • homeassistant.deanoftech.com (app: homeassistant)
+  • my-app.deanoftech.com (app: my-app)
+  • nextcloud.deanoftech.com (app: nextcloud)
+  • nextcloud-data.deanoftech.com (app: nextcloud-data)
+  • penpot.deanoftech.com (app: penpot)
+  • recipe-book.deanoftech.com (app: recipe-book)
+  • recipebook.deanoftech.com (app: recipebook)
+  • recipes-api.deanoftech.com (app: recipes-api)
+  • savepage-server.deanoftech.com (app: savepage-server)
+  • transmission.deanoftech.com (app: transmission)
+  • uptime-kuma.deanoftech.com (app: uptime-kuma)
+
+=====> AWS Route53 Information
+-----> Zone ID: Z0444961AB4Z3I5DF5NH
+-----> Zone Name: deanoftech.com
+-----> Record Count: 29
+-----> Type: Public Zone
+-----> Name Servers: ns-1264.awsdns-30.org      ns-56.awsdns-07.com     ns-1964.awsdns-53.co.uk    ns-689.awsdns-22.net
+~$

--- a/test-output-examples/provider-verify-output.txt
+++ b/test-output-examples/provider-verify-output.txt
@@ -1,0 +1,55 @@
+~$ dokku dns:providers:verify
+=====> Checking Dependencies
+----->   jq: available (jq-1.7)
+
+=====> Auto-detected provider: AWS Route53
+
+-----> To add additional providers, configure their credentials:
+----->   Cloudflare: dokku config:set --global CLOUDFLARE_API_TOKEN=your_token
+----->   DigitalOcean: dokku config:set --global DIGITALOCEAN_ACCESS_TOKEN=your_token
+
+=====> Verifying aws provider
+
+-----> Current Configuration:
+----->   DNS Provider: aws
+=====> AWS Route53 Setup
+
+----->   AWS CLI: installed (aws-cli/2.27.58)
+
+-----> Credential Detection:
+----->   ✗ Environment variables: not set
+----->   YES AWS config files: ~/.aws/credentials, ~/.aws/config
+----->   ✗ IAM Role: not available
+
+-----> Testing AWS Authentication:
+----->   Authentication successful (current context)
+
+-----> AWS Account Details:
+----->   Account ID: 780741804266
+----->   User/Role ARN: arn:aws:iam::780741804266:user/dean
+----->   User ID: AIDAJQEQZBPEQFM3MHQLY
+----->   Region: us-east-1
+
+-----> Testing Route53 API Access:
+----->   route53:ListHostedZones - can list hosted zones
+----->   Found 2 hosted zone(s)
+----->   route53:ListResourceRecordSets - can read DNS records
+----->   ? route53:ChangeResourceRecordSets - will be tested during actual sync operations
+
+-----> Hosted Zones Discovery:
+-----------------------------------------------------------------------------
+|                              ListHostedZones                              |
++-----------------------------------+----------+--------+-------------------+
+|                ID                 | Records  | Type   |       Zone        |
++-----------------------------------+----------+--------+-------------------+
+|  /hostedzone/ZZ36BKMR6SB53        |  10      |  False |  dean.is.         |
+|  /hostedzone/Z0444961AB4Z3I5DF5NH |  29      |  False |  deanoftech.com.  |
++-----------------------------------+----------+--------+-------------------+
+
+-----> Dokku DNS Records Discovery:
+----->   No existing Dokku DNS records found
+
+-----> aws provider verification complete
+
+
+-----> DNS Provider Verification Complete


### PR DESCRIPTION
## Summary

This PR adds Phase 26 to fix critical issues found during manual testing and reorganizes the TODO phases based on comprehensive code review.

### New Phase 26: Fix Test Output Issues

Created `test-output-examples/` folder with real command outputs showing issues:

1. **provider-verify-output.txt** - Excessive verbosity
   - Multiple redundant heading levels
   - Full AWS account details shown unnecessarily
   - Zone table too detailed

2. **apps-enable.txt** - Conflicting information
   - Says "✓ zone enabled" then shows "No (no hosted zone)"
   - Status indicators don't match actual state
   - Confusing provider column

3. **no-zones-found.txt** - Critical sync failure
   - `dns:apps:sync` says "No hosted zone found"
   - Zone is enabled and visible in `dns:zones` command
   - Zone lookup completely broken in sync operation

4. **app-create-trigger-fail.txt** - Trigger zone detection failure
   - post-create trigger says "No domains configured"
   - Domain exists (my-test-app.deanoftech.com)
   - Domain is in enabled zone but not detected

### Phase Reorganization

Reorganized TODO phases around 1.0 release:

**Pre-Release (Critical):**
- Phase 26: Fix Test Output Issues ⬅️ NEW
- Phase 27: Code Quality - Critical Fixes (linting, unsafe patterns, installation)
- Phase 28: Code Quality - High Priority Refactoring (duplicate code, validation)

**Pre-Release (Testing):**
- Phase 29: Pre-Release Testing & Validation

**Release:**
- Phase 30: 1.0 Release

**Post-Release:**
- Phase 31: Community & Support
- Phases 32-33: Code Quality cleanup (post-1.0)

### Additional TODOs Added

- Update install script to focus on zones (not just apps)
- Add triggers:enable to getting started
- Create missing `dns:zones:sync` command
- Improve zone enable output with copy-pastable commands

### Impact

These test output files provide concrete examples for fixing the most critical user-facing issues before 1.0 release. Each issue has a test case for verification.

🤖 Generated with [Claude Code](https://claude.ai/code)