### PR TITLE
Phase 26: Fix zone lookup failures in DNS sync operations

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -119,7 +119,10 @@
       "Bash(gh api:*)",
       "Bash(./commands dns help)",
       "Bash(env PLUGIN_DATA_ROOT=\"/tmp/dns-test\" ./commands dns providers:verify)",
-      "Bash(env:*)"
+      "Bash(env:*)",
+      "Bash(SKIP_TESTS=1 git commit -m \"docs: reorder phases around 1.0 release\n\nReorganize phases to make logical sense:\n- Phases 26-27: Code quality fixes (critical and high priority) BEFORE release\n- Phase 28: Pre-release testing and validation\n- Phase 29: 1.0 Release\n- Phase 30: Community & Support (post-release activities)\n- Phases 31-32: Medium and low priority cleanup (post-1.0)\n\nThis ensures critical fixes happen before release, not after.\n\n🤖 Generated with [Claude Code](https://claude.ai/code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\")",
+      "Bash(SKIP_TESTS=1 git commit -m \"docs: add installation issues to Phase 26\n\nAdd todos for fixing installation detection:\n- Remove deprecated ''default DNS provider'' concept\n- Add DigitalOcean detection to install script\n- Report multi-provider mode properly during installation\n- Remove PROVIDER file creation (no longer needed)\n\n🤖 Generated with [Claude Code](https://claude.ai/code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\")",
+      "Bash(gh pr list:*)"
     ],
     "deny": [],
     "defaultMode": "acceptEdits"

--- a/TODO.md
+++ b/TODO.md
@@ -176,6 +176,14 @@ See `test-output-examples/` folder for actual command outputs showing these issu
   - [ ] Replace hardcoded TTL values in adapter.sh:202, 218 with constants
   - [ ] Update all TTL validation to use constants
 
+- [ ] **Remove MULTI_PROVIDER_MODE Flag**
+  - [ ] Remove MULTI_PROVIDER_MODE environment variable (always true, legacy code)
+  - [ ] Remove all `if [[ "${MULTI_PROVIDER_MODE:-false}" == "true" ]]` conditionals in adapter.sh
+  - [ ] Always call multi_* functions (multi_get_zone_id, multi_get_record, etc.)
+  - [ ] Delete dead code branches that call provider_* directly (lines 147-155 in adapter.sh)
+  - [ ] Update init_provider_system to always use multi-provider routing
+  - [ ] Remove "Multi-provider mode activated" messages (it's the only mode)
+
 
 ### Phase 28: Code Quality - High Priority Refactoring (Pre-Release)
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,13 @@ See `test-output-examples/` folder for actual command outputs showing these issu
   - [ ] Fix is_domain_in_enabled_zone function or post-create timing
   - [ ] Test: my-test-app.deanoftech.com should be detected in enabled deanoftech.com zone
 
+- [ ] **Fix destroy-trigger.txt Issues**
+  - [ ] App destroy queues domains for deletion but sync:deletions fails
+  - [ ] sync:deletions says "No enabled zones found" despite zones being enabled
+  - [ ] Orphaned DNS records are never deleted from Route53
+  - [ ] Fix sync:deletions to use same zone detection as other commands
+  - [ ] Test: my-test-app.deanoftech.com should be deleted after app destroy
+
 
 ### Phase 27: Code Quality - Critical Fixes (Pre-Release)
 

--- a/commands
+++ b/commands
@@ -9,7 +9,7 @@ fi
 
 # Define missing functions if needed
 if ! declare -f dokku_log_fail >/dev/null 2>&1; then
-  # shellcheck disable=SC2329
+  # shellcheck disable=SC2329,SC2317
   dokku_log_fail() {
     echo " !     $*" >&2
     exit 1

--- a/commands
+++ b/commands
@@ -9,7 +9,7 @@ fi
 
 # Define missing functions if needed
 if ! declare -f dokku_log_fail >/dev/null 2>&1; then
-  # shellcheck disable=SC2317
+  # shellcheck disable=SC2329
   dokku_log_fail() {
     echo " !     $*" >&2
     exit 1

--- a/providers/adapter.sh
+++ b/providers/adapter.sh
@@ -138,7 +138,7 @@ dns_sync_app() {
     local zone_id
     if [[ "${MULTI_PROVIDER_MODE:-false}" == "true" ]]; then
       if ! zone_id=$(multi_get_zone_id "$domain"); then
-        echo "❌ No hosted zone found (multi-provider mode)"
+        echo "❌ No hosted zone found"
         continue
       fi
 

--- a/providers/adapter.sh
+++ b/providers/adapter.sh
@@ -137,15 +137,15 @@ dns_sync_app() {
     # Get zone ID for this domain
     local zone_id
     if [[ "${MULTI_PROVIDER_MODE:-false}" == "true" ]]; then
-      if ! zone_id=$(multi_get_zone_id "$domain" 2>/dev/null); then
-        echo "❌ No hosted zone found"
+      if ! zone_id=$(multi_get_zone_id "$domain"); then
+        echo "❌ No hosted zone found (multi-provider mode)"
         continue
       fi
 
       # Check current record
       current_ip=$(multi_get_record "$zone_id" "$domain" "A" 2>/dev/null || echo "")
     else
-      if ! zone_id=$(provider_get_zone_id "$domain" 2>/dev/null); then
+      if ! zone_id=$(provider_get_zone_id "$domain"); then
         echo "❌ No hosted zone found"
         continue
       fi

--- a/providers/available
+++ b/providers/available
@@ -2,3 +2,4 @@ mock
 aws
 cloudflare
 digitalocean
+template

--- a/providers/available
+++ b/providers/available
@@ -2,4 +2,3 @@ mock
 aws
 cloudflare
 digitalocean
-template

--- a/providers/loader.sh
+++ b/providers/loader.sh
@@ -68,11 +68,6 @@ validate_provider() {
 load_provider() {
   local provider_name="$1"
 
-  # Skip if already loaded
-  if [[ " ${LOADED_PROVIDERS[*]} " =~ \ ${provider_name}\  ]]; then
-    return 0
-  fi
-
   # Validate provider first
   if ! validate_provider "$provider_name"; then
     return 1
@@ -91,8 +86,10 @@ load_provider() {
     provider_setup_env
   fi
 
-  # Add to loaded providers list
-  LOADED_PROVIDERS+=("$provider_name")
+  # Add to loaded providers list if not already there
+  if ! [[ " ${LOADED_PROVIDERS[*]} " =~ \ ${provider_name}\  ]]; then
+    LOADED_PROVIDERS+=("$provider_name")
+  fi
 
   echo "Loaded provider: $provider_name" >&2
   return 0

--- a/providers/multi-provider.sh
+++ b/providers/multi-provider.sh
@@ -117,12 +117,10 @@ multi_get_zone_id() {
     return 1
   fi
 
-  # Load the provider if not already loaded
-  if ! is_provider_loaded "$provider"; then
-    if ! load_provider "$provider"; then
-      echo "Failed to load provider: $provider" >&2
-      return 1
-    fi
+  # Load the provider to ensure its functions are active
+  if ! load_provider "$provider" 2>/dev/null; then
+    echo "Failed to load provider: $provider" >&2
+    return 1
   fi
 
   # Get zone ID from the provider
@@ -150,9 +148,10 @@ multi_get_record() {
     return 1
   fi
 
-  # Load provider and execute
-  if ! is_provider_loaded "$provider"; then
-    load_provider "$provider" >/dev/null
+  # Load provider to ensure its functions are active
+  if ! load_provider "$provider" 2>/dev/null; then
+    echo "Failed to load provider: $provider" >&2
+    return 1
   fi
 
   provider_get_record "$zone_id" "$record_name" "$record_type"
@@ -181,9 +180,10 @@ multi_create_record() {
     return 1
   fi
 
-  # Load provider and execute
-  if ! is_provider_loaded "$provider"; then
-    load_provider "$provider" >/dev/null
+  # Load provider to ensure its functions are active
+  if ! load_provider "$provider" 2>/dev/null; then
+    echo "Failed to load provider: $provider" >&2
+    return 1
   fi
 
   provider_create_record "$zone_id" "$record_name" "$record_type" "$record_value" "$ttl"
@@ -210,9 +210,10 @@ multi_delete_record() {
     return 1
   fi
 
-  # Load provider and execute
-  if ! is_provider_loaded "$provider"; then
-    load_provider "$provider" >/dev/null
+  # Load provider to ensure its functions are active
+  if ! load_provider "$provider" 2>/dev/null; then
+    echo "Failed to load provider: $provider" >&2
+    return 1
   fi
 
   provider_delete_record "$zone_id" "$record_name" "$record_type"

--- a/test-output-examples/destroy-trigger.txt
+++ b/test-output-examples/destroy-trigger.txt
@@ -1,0 +1,62 @@
+$ dokku apps:destroy my-test-app
+ !     WARNING: Potentially Destructive Action
+ !     This command will destroy app my-test-app.
+ !     To proceed, type "my-test-app"
+> my-test-app
+-----> Destroying my-test-app (including all add-ons)
+       Unlinking from nextcloud-memcached
+       Unlinking from controlcopypasta
+       Unlinking from core_db
+       Unlinking from ddclient_db
+       Unlinking from dot_db
+       Unlinking from mealie-db
+       Unlinking from myapp_db
+       Unlinking from nextcloud_postgres
+       Unlinking from postgres-dokku-ui
+       Unlinking from railsdatabase
+       Unlinking from readeck-db
+       Unlinking from recipe-book
+       Unlinking from recipebook
+       Unlinking from recipes-db
+       Unlinking from nextcloud-redis
+=====> DNS: Cleaning up DNS management for app 'my-test-app'
+-----> DNS: Removing DNS management for domains:
+----->   • my-test-app.deanoftech.com
+-----> DNS: App 'my-test-app' removed from DNS management
+-----> DNS: Domains queued for cleanup: my-test-app.deanoftech.com
+-----> DNS: Run 'dokku dns:sync:deletions' to clean up orphaned DNS records
+-----> Updated schedule file
+-----> Cleaning up...
+-----> Retiring old containers and images
+~$ dokku dns:sync-all
+[2025-10-02 14:57:50 EDT] Starting DNS sync-all operation
+=====> Using provider system for DNS sync (supports multi-provider)
+Initializing multi-provider DNS system...
+Discovering zones from all providers...
+  Checking provider: mock
+    ✗ mock: invalid credentials
+  Checking provider: aws
+    ✓ aws credentials valid
+    ✓ aws manages 2 zone(s)
+  Checking provider: cloudflare
+    ✗ cloudflare: invalid credentials
+  Checking provider: digitalocean
+    ✗ digitalocean: invalid credentials
+Zone discovery complete: 1 working provider(s)
+Multi-provider system ready: 1 provider(s) active
+Multi-provider mode activated
+-----> Syncing DNS records for app: recipes
+Syncing domains for app 'recipes' to server IP: 68.55.81.191
+
+Analyzing current DNS records...
+  Checking recipes.deanoftech.com... ✅ Already correct
+
+No changes needed! All DNS records are already correct.
+-----> Successfully synced DNS for: recipes
+[2025-10-02 14:58:02 EDT] DNS sync-all operation completed
+-----> Batch DNS sync completed
+~$ dokku dns:sync:deletions
+-----> DNS Record Cleanup
+=====> Found 27 domains across controlcopypasta ddclient dean-is headless-chrome homeassistant my-app nextcloud nextcloud-data penpot recipe-book recipebook recipes recipes-api savepage-server transmission uptime-kuma  apps
+ !     No enabled zones found. Use 'dokku dns:zones:enable <zone>' to enable zones first.
+~$


### PR DESCRIPTION
## Summary

Fixes critical bug where DNS sync operations failed with "No hosted zone found" error despite zones existing and being enabled in Route53.

## Root Cause

The provider discovery process loads each provider sequentially. Since all providers share the same function names (`provider_get_zone_id`, etc.), the last loaded provider's functions overwrite all previous ones in the global namespace.

This caused sync to fail because:
1. Discovery loaded all providers (mock, aws, cloudflare, digitalocean, template)
2. Template was loaded last, overwriting AWS functions
3. Provider wrappers checked `is_provider_loaded("aws")` → true
4. They didn't reload AWS, so template's functions remained active
5. Template's `provider_get_zone_id` only works for example.com/test.org
6. Real domains like deanoftech.com failed with "zone not found"

## Changes

- ✅ Remove template from `providers/available` (it's just a template, not a real provider)
- ✅ Remove "skip if already loaded" check in `load_provider()` to ensure correct functions are always active
- ✅ Update all provider wrappers to always reload the provider before calling its functions
- ✅ Remove stderr suppression from zone lookups to show error messages
- ✅ Fix shellcheck warning in commands file
- ✅ Add destroy-trigger.txt issue to TODO.md Phase 26

## Test Plan

Tested on production server:
- ✅ `dokku dns:apps:sync recipes` now successfully finds deanoftech.com zone
- ✅ Detects missing records and creates them
- ✅ Detects incorrect IPs and updates them

## Related Issues

Fixes Phase 26 issue #3 from TODO.md (no-zones-found.txt zone lookup failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)