### PR TITLE
ci: update shellcheck to v0.11.0 and shfmt to v3.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,14 @@ jobs:
 
       - name: Install linting dependencies
         run: |
-          # Install system dependencies for linting
-          sudo apt-get update -qq
-          sudo apt-get install -qq -y shellcheck
+          # Install shellcheck 0.11.0
+          wget -qO /tmp/shellcheck.tar.xz https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
+          tar -xf /tmp/shellcheck.tar.xz -C /tmp
+          sudo mv /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
+          sudo chmod +x /usr/local/bin/shellcheck
 
-          # Install shfmt
-          wget -qO /tmp/shfmt https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64
+          # Install shfmt 3.12.0
+          wget -qO /tmp/shfmt https://github.com/mvdan/sh/releases/download/v3.12.0/shfmt_v3.12.0_linux_amd64
           chmod +x /tmp/shfmt
           sudo mv /tmp/shfmt /usr/local/bin/shfmt
 


### PR DESCRIPTION
## Summary
- Update shellcheck from apt-provided version to v0.11.0 (matching local dev)
- Update shfmt from v3.8.0 to v3.12.0 (matching local dev)

## Changes
Both tools are now downloaded directly from GitHub releases instead of using package managers, ensuring consistent versions between CI and local development environments.

🤖 Generated with [Claude Code](https://claude.ai/code)