### PR TITLE
Phase 28: Reduce provider:verify output verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,14 @@ By default, adds all domains configured for the app optionally specify specific 
 dokku dns:providers:verify <provider-arg>
 ```
 
+flags:
+
+- `-v|--verbose`: show detailed output (default shows summary only)
+
 Verify `DNS` provider setup and connectivity, discover existing `DNS` records:
 
 ```shell
-dokku dns:providers:verify [provider]
+dokku dns:providers:verify [--verbose] [provider]
 ```
 
 Verify specific provider or all available providers if none specified checks credentials, tests `API` access, shows available zones/domains for each provider:

--- a/TODO.md
+++ b/TODO.md
@@ -3,22 +3,6 @@
 The DNS plugin is in progress! Many core features have been implemented and tested. See [DONE.md](./DONE.md) for completed work.
 
 
-### Phase 28: Display and Reporting Fixes (Pre-Release) ✅
-
-**Status:** COMPLETE
-
-**Completed Work:**
-- ✅ Zone lookup fixes (PR #66)
-- ✅ Reduce provider:verify output verbosity
-  - Added --verbose flag for detailed output
-  - Default shows concise summary (provider: status, zone count)
-  - Scales well with many providers (1-5+)
-  - Wrapped all detailed output in verbose mode
-  - Intelligent zone display (first 2-3 zones, then "+N more")
-
-See DONE.md for full details.
-
-
 ### Phase 29: Trigger System Improvements (Pre-Release)
 
 **Objective:** Fix post-create trigger failing to detect auto-added domains from global vhost.

--- a/TODO.md
+++ b/TODO.md
@@ -3,20 +3,20 @@
 The DNS plugin is in progress! Many core features have been implemented and tested. See [DONE.md](./DONE.md) for completed work.
 
 
-### Phase 28: Display and Reporting Fixes (Pre-Release)
+### Phase 28: Display and Reporting Fixes (Pre-Release) ✅
 
-**Objective:** Reduce excessive output verbosity in provider verification.
+**Status:** COMPLETE
 
-**Note:** Zone lookup fixes completed in PR #66 - see DONE.md Phase 28.
+**Completed Work:**
+- ✅ Zone lookup fixes (PR #66)
+- ✅ Reduce provider:verify output verbosity
+  - Added --verbose flag for detailed output
+  - Default shows concise summary (provider: status, zone count)
+  - Scales well with many providers (1-5+)
+  - Wrapped all detailed output in verbose mode
+  - Intelligent zone display (first 2-3 zones, then "+N more")
 
-- [ ] **Reduce provider:verify Output Verbosity**
-  - [ ] Reduce excessive verbosity (multiple heading levels, redundant messages)
-  - [ ] Condense zone listing (don't show every zone detail in table)
-  - [ ] Remove redundant "checking" messages
-  - [ ] Show summary counts instead of full credential detection lists
-  - [ ] Add --verbose flag for detailed output if needed
-  - **Problem:** `dns:providers:verify` output is excessively verbose
-  - **Reference:** See `test-output-examples/provider-verify-output.txt`
+See DONE.md for full details.
 
 
 ### Phase 29: Trigger System Improvements (Pre-Release)

--- a/subcommands/providers:verify
+++ b/subcommands/providers:verify
@@ -27,23 +27,50 @@ fi
 
 source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
 
+# Helper functions for conditional output based on verbose flag
+verbose_log_info1() {
+  [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "$@"
+}
+
+verbose_log_info2() {
+  [[ "$VERBOSE" == "true" ]] && dokku_log_info2 "$@"
+}
+
+verbose_echo() {
+  [[ "$VERBOSE" == "true" ]] && echo
+}
+
 service-providers-verify-cmd() {
   #E verify DNS provider setup and connectivity, discover existing DNS records
-  #E dokku $PLUGIN_COMMAND_PREFIX:providers:verify [provider]
+  #E dokku $PLUGIN_COMMAND_PREFIX:providers:verify [--verbose] [provider]
   #E verify specific provider or all available providers if none specified
   #E checks credentials, tests API access, shows available zones/domains for each provider
+  #F -v|--verbose, show detailed output (default shows summary only)
   #A provider, optional DNS provider to verify (aws, cloudflare, digitalocean) - defaults to all available providers
   declare desc="verify DNS provider setup and connectivity"
   local cmd="$PLUGIN_COMMAND_PREFIX:providers:verify" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
-  
-  local PROVIDER_ARG="$1"
+
+  # Parse flags
+  local VERBOSE=false
+  local PROVIDER_ARG=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -v|--verbose)
+        VERBOSE=true
+        shift
+        ;;
+      *)
+        PROVIDER_ARG="$1"
+        shift
+        ;;
+    esac
+  done
+
   local GLOBAL_CONFIG_ROOT="$PLUGIN_DATA_ROOT"
 
-  # Check dependencies first
-  dokku_log_info2 "Checking Dependencies"
-
-  # Check jq following Dokku guidelines
+  # Check dependencies first (only in verbose mode or if missing)
   if ! command -v jq &>/dev/null; then
     dokku_log_fail "Missing jq, install it
 
@@ -55,11 +82,13 @@ Install jq:
   macOS (Homebrew): brew install jq
 
 Or download from: https://stedolan.github.io/jq/download/"
-  else
-    dokku_log_info1 "  jq: available ($(jq --version))"
   fi
 
-  echo
+  if [[ "$VERBOSE" == "true" ]]; then
+    dokku_log_info2 "Checking Dependencies"
+    dokku_log_info1 "  jq: available ($(jq --version))"
+    echo
+  fi
 
   # Load the provider loader system
   local LOADER_PATH
@@ -111,17 +140,19 @@ Or download from: https://stedolan.github.io/jq/download/"
 
     PROVIDERS_TO_VERIFY=("${configured_providers[@]}")
 
-    # If only AWS is configured, show a friendly message
-    if [[ ${#configured_providers[@]} -eq 1 ]] && [[ "${configured_providers[0]}" == "aws" ]]; then
-      dokku_log_info2 "Auto-detected provider: AWS Route53"
-      echo
-      dokku_log_info1 "To add additional providers, configure their credentials:"
-      dokku_log_info1 "  Cloudflare: dokku config:set --global CLOUDFLARE_API_TOKEN=your_token"
-      dokku_log_info1 "  DigitalOcean: dokku config:set --global DIGITALOCEAN_ACCESS_TOKEN=your_token"
-      echo
-    elif [[ ${#configured_providers[@]} -gt 1 ]]; then
-      dokku_log_info2 "Auto-detected providers: ${configured_providers[*]}"
-      echo
+    if [[ "$VERBOSE" == "true" ]]; then
+      # If only AWS is configured, show a friendly message
+      if [[ ${#configured_providers[@]} -eq 1 ]] && [[ "${configured_providers[0]}" == "aws" ]]; then
+        dokku_log_info2 "Auto-detected provider: AWS Route53"
+        echo
+        dokku_log_info1 "To add additional providers, configure their credentials:"
+        dokku_log_info1 "  Cloudflare: dokku config:set --global CLOUDFLARE_API_TOKEN=your_token"
+        dokku_log_info1 "  DigitalOcean: dokku config:set --global DIGITALOCEAN_ACCESS_TOKEN=your_token"
+        echo
+      elif [[ ${#configured_providers[@]} -gt 1 ]]; then
+        dokku_log_info2 "Auto-detected providers: ${configured_providers[*]}"
+        echo
+      fi
     fi
   fi
 
@@ -136,55 +167,72 @@ Or download from: https://stedolan.github.io/jq/download/"
   chmod 700 "$CREDENTIALS_DIR" 2>/dev/null || true
 
   # Function to verify a specific provider
+  # Returns: Sets global PROVIDER_SUMMARY variables for summary display
   verify_provider() {
     local provider_name="$1"
 
-    dokku_log_info2 "Verifying $provider_name provider"
-    echo
+    # Initialize summary data (will be used in non-verbose mode)
+    PROVIDER_SUMMARY_NAME="$provider_name"
+    PROVIDER_SUMMARY_STATUS="unknown"
+    PROVIDER_SUMMARY_ZONE_COUNT=0
+    PROVIDER_SUMMARY_ZONES=()
+    PROVIDER_SUMMARY_ERROR=""
+
+    verbose_log_info2 "Verifying $provider_name provider"
+    verbose_echo
 
     # Try to load the provider
     if ! load_specific_provider "$provider_name" >/dev/null 2>&1; then
-      dokku_log_info1 "  ✗ Provider '$provider_name' failed to load"
+      verbose_log_info1 "  ✗ Provider '$provider_name' failed to load"
+      PROVIDER_SUMMARY_STATUS="failed"
+      PROVIDER_SUMMARY_ERROR="failed to load"
       return 1
     fi
 
-    dokku_log_info1 "Current Configuration:"
-    dokku_log_info1 "  DNS Provider: $provider_name"
+    verbose_log_info1 "Current Configuration:"
+    verbose_log_info1 "  DNS Provider: $provider_name"
 
     case "$provider_name" in
     aws)
-      dokku_log_info2 "AWS Route53 Setup"
-      echo
-      
+      if [[ "$VERBOSE" == "true" ]]; then
+        dokku_log_info2 "AWS Route53 Setup"
+        echo
+      fi
+
       # Check if AWS CLI is installed
       if ! command -v aws >/dev/null 2>&1; then
-        dokku_log_info1 "  ✗ AWS CLI: not installed"
-        echo
-        dokku_log_fail "AWS CLI is not installed. Please install it first:
-  
+        PROVIDER_SUMMARY_STATUS="failed"
+        PROVIDER_SUMMARY_ERROR="AWS CLI not installed"
+        if [[ "$VERBOSE" == "true" ]]; then
+          dokku_log_info1 "  ✗ AWS CLI: not installed"
+          echo
+          dokku_log_fail "AWS CLI is not installed. Please install it first:
+
   # Ubuntu/Debian:
   sudo apt update && sudo apt install awscli
-  
+
   # macOS:
   brew install awscli
-  
+
   # Or install via pip:
   pip install awscli
-  
+
   # Or download from AWS:
   curl \"https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip\" -o \"awscliv2.zip\"
   unzip awscliv2.zip
   sudo ./aws/install"
-      else
+        fi
+        return 1
+      fi
+
+      if [[ "$VERBOSE" == "true" ]]; then
         local AWS_VERSION
         AWS_VERSION=$(aws --version 2>/dev/null | cut -d' ' -f1 || echo "unknown")
         dokku_log_info1 "  AWS CLI: installed ($AWS_VERSION)"
+        echo
+        # Check AWS credentials and configuration
+        dokku_log_info1 "Credential Detection:"
       fi
-      
-      echo
-      
-      # Check AWS credentials and configuration
-      dokku_log_info1 "Credential Detection:"
       
       # Helper function to run AWS commands with correct user context
       run_aws_command() {
@@ -199,19 +247,19 @@ Or download from: https://stedolan.github.io/jq/download/"
         fi
       }
       
-      # Check different credential sources
+      # Check different credential sources (always check, only show if verbose)
       local CREDENTIALS_DETECTED=false
       local CREDENTIAL_SOURCE=""
-      
+
       # Check environment variables
       if [[ -n "${AWS_ACCESS_KEY_ID:-}" ]] && [[ -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
-        dokku_log_info1 "  Environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  Environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"
         CREDENTIALS_DETECTED=true
         CREDENTIAL_SOURCE="environment"
       else
-        dokku_log_info1 "  ✗ Environment variables: not set"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ✗ Environment variables: not set"
       fi
-      
+
       # Check AWS CLI configuration files
       local AWS_CONFIG_STATUS="✗"
       if [[ -f ~/.aws/credentials ]] || [[ -f ~/.aws/config ]]; then
@@ -221,42 +269,47 @@ Or download from: https://stedolan.github.io/jq/download/"
           CREDENTIAL_SOURCE="aws-config"
         fi
       fi
-      dokku_log_info1 "  $AWS_CONFIG_STATUS AWS config files: ~/.aws/credentials, ~/.aws/config"
-      
+      [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  $AWS_CONFIG_STATUS AWS config files: ~/.aws/credentials, ~/.aws/config"
+
       # Check IAM role (EC2 metadata)
       if curl -s --max-time 2 http://169.254.169.254/latest/meta-data/iam/security-credentials/ >/dev/null 2>&1; then
-        dokku_log_info1 "  IAM Role: available (EC2 instance)"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  IAM Role: available (EC2 instance)"
         CREDENTIALS_DETECTED=true
         if [[ -z "$CREDENTIAL_SOURCE" ]]; then
           CREDENTIAL_SOURCE="iam-role"
         fi
       else
-        dokku_log_info1 "  ✗ IAM Role: not available"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ✗ IAM Role: not available"
       fi
-      
-      echo
+
+      [[ "$VERBOSE" == "true" ]] && echo
       
       # Try to authenticate and get AWS identity
-      dokku_log_info1 "Testing AWS Authentication:"
+      [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "Testing AWS Authentication:"
       local AWS_CHECK_SUCCESS=false
-      
+
       if run_aws_command sts get-caller-identity >/dev/null 2>&1; then
         AWS_CHECK_SUCCESS=true
         # Determine which context is working for user feedback
-        if aws sts get-caller-identity >/dev/null 2>&1; then
-          dokku_log_info1 "  Authentication successful (current context)"
-        elif [[ -n "${SUDO_USER:-}" ]]; then
-          dokku_log_info1 "  Authentication successful (user: $SUDO_USER)"
-        else
-          dokku_log_info1 "  Authentication successful (dokku user)"
+        if [[ "$VERBOSE" == "true" ]]; then
+          if aws sts get-caller-identity >/dev/null 2>&1; then
+            dokku_log_info1 "  Authentication successful (current context)"
+          elif [[ -n "${SUDO_USER:-}" ]]; then
+            dokku_log_info1 "  Authentication successful (user: $SUDO_USER)"
+          else
+            dokku_log_info1 "  Authentication successful (dokku user)"
+          fi
         fi
       else
-        dokku_log_info1 "  ✗ Authentication failed"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ✗ Authentication failed"
       fi
-      
+
       if [[ "$AWS_CHECK_SUCCESS" != "true" ]]; then
-        echo
-        dokku_log_fail "AWS CLI is not configured or credentials are invalid.
+        PROVIDER_SUMMARY_STATUS="failed"
+        PROVIDER_SUMMARY_ERROR="authentication failed"
+        if [[ "$VERBOSE" == "true" ]]; then
+          echo
+          dokku_log_fail "AWS CLI is not configured or credentials are invalid.
 
 Please configure AWS credentials using one of these methods:
 
@@ -286,96 +339,119 @@ Required AWS Permissions:
   - route53:ChangeResourceRecordSets
 
 For more info: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html"
+        fi
+        return 1
       fi
-      
-      echo
-      
-      # Get detailed AWS identity information
-      dokku_log_info1 "AWS Account Details:"
+
+      if [[ "$VERBOSE" == "true" ]]; then
+        echo
+        # Get detailed AWS identity information
+        dokku_log_info1 "AWS Account Details:"
+      fi
       local AWS_IDENTITY AWS_USER_ID AWS_ACCOUNT AWS_REGION AWS_ARN
-      
+
       AWS_IDENTITY=$(run_aws_command sts get-caller-identity)
       AWS_REGION=$(run_aws_command configure get region 2>/dev/null || echo "not-set")
-      
+
       if [[ -n "$AWS_IDENTITY" ]]; then
         AWS_USER_ID=$(echo "$AWS_IDENTITY" | jq -r '.UserId' 2>/dev/null || echo "unknown")
         AWS_ACCOUNT=$(echo "$AWS_IDENTITY" | jq -r '.Account' 2>/dev/null || echo "unknown")
         AWS_ARN=$(echo "$AWS_IDENTITY" | jq -r '.Arn' 2>/dev/null || echo "unknown")
-        
-        dokku_log_info1 "  Account ID: $AWS_ACCOUNT"
-        dokku_log_info1 "  User/Role ARN: $AWS_ARN"
-        dokku_log_info1 "  User ID: $AWS_USER_ID"
-        dokku_log_info1 "  Region: $AWS_REGION"
-        
-        if [[ "$AWS_REGION" == "not-set" ]]; then
-          dokku_log_warn "  No default region set. Consider setting AWS_DEFAULT_REGION"
+
+        if [[ "$VERBOSE" == "true" ]]; then
+          dokku_log_info1 "  Account ID: $AWS_ACCOUNT"
+          dokku_log_info1 "  User/Role ARN: $AWS_ARN"
+          dokku_log_info1 "  User ID: $AWS_USER_ID"
+          dokku_log_info1 "  Region: $AWS_REGION"
+
+          if [[ "$AWS_REGION" == "not-set" ]]; then
+            dokku_log_warn "  No default region set. Consider setting AWS_DEFAULT_REGION"
+          fi
         fi
       else
-        dokku_log_info1 "  ✗ Could not retrieve AWS identity"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ✗ Could not retrieve AWS identity"
       fi
-      
-      echo
+
+      [[ "$VERBOSE" == "true" ]] && echo
       
       # Test Route53 permissions comprehensively
-      dokku_log_info1 "Testing Route53 API Access:"
+      [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "Testing Route53 API Access:"
       local ROUTE53_SUCCESS=false
-      
+
       # Test list-hosted-zones permission
       if run_aws_command route53 list-hosted-zones >/dev/null 2>&1; then
-        dokku_log_info1 "  route53:ListHostedZones - can list hosted zones"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  route53:ListHostedZones - can list hosted zones"
         ROUTE53_SUCCESS=true
-        
-        # Get zone count
+
+        # Get zone count and names for summary
         local ZONE_COUNT
         ZONE_COUNT=$(run_aws_command route53 list-hosted-zones --query 'length(HostedZones)' --output text 2>/dev/null || echo "0")
-        dokku_log_info1 "  Found $ZONE_COUNT hosted zone(s)"
-        
+        PROVIDER_SUMMARY_ZONE_COUNT="$ZONE_COUNT"
+
+        # Get zone names for summary
+        local zone_names
+        zone_names=$(run_aws_command route53 list-hosted-zones --query 'HostedZones[].Name' --output text 2>/dev/null | tr '\t' ' ')
+        if [[ -n "$zone_names" ]]; then
+          # Convert to array
+          IFS=' ' read -r -a PROVIDER_SUMMARY_ZONES <<< "$zone_names"
+        fi
+
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  Found $ZONE_COUNT hosted zone(s)"
+
         # Test record listing if zones exist
         if [[ "$ZONE_COUNT" -gt 0 ]]; then
           local FIRST_ZONE_ID
           FIRST_ZONE_ID=$(run_aws_command route53 list-hosted-zones --query 'HostedZones[0].Id' --output text 2>/dev/null | sed 's|/hostedzone/||')
-          
+
           if [[ -n "$FIRST_ZONE_ID" ]] && run_aws_command route53 list-resource-record-sets --hosted-zone-id "$FIRST_ZONE_ID" >/dev/null 2>&1; then
-            dokku_log_info1 "  route53:ListResourceRecordSets - can read DNS records"
+            [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  route53:ListResourceRecordSets - can read DNS records"
           else
-            dokku_log_info1 "  route53:ListResourceRecordSets - permission test failed"
+            [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  route53:ListResourceRecordSets - permission test failed"
           fi
-          
+
           # Note: We can't easily test ChangeResourceRecordSets without making actual changes
-          dokku_log_info1 "  ? route53:ChangeResourceRecordSets - will be tested during actual sync operations"
+          [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ? route53:ChangeResourceRecordSets - will be tested during actual sync operations"
         fi
+
+        PROVIDER_SUMMARY_STATUS="success"
       else
-        dokku_log_info1 "  ✗ route53:ListHostedZones - permission denied or API error"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ✗ route53:ListHostedZones - permission denied or API error"
+        PROVIDER_SUMMARY_STATUS="failed"
+        PROVIDER_SUMMARY_ERROR="route53 permission denied"
       fi
       
       if [[ "$ROUTE53_SUCCESS" == "true" ]]; then
-        echo
-        dokku_log_info1 "Hosted Zones Discovery:"
-        
-        # Show available hosted zones in a nice format
-        local ZONES_OUTPUT
-        ZONES_OUTPUT=$(run_aws_command route53 list-hosted-zones --query 'HostedZones[].{Zone:Name,ID:Id,Records:ResourceRecordSetCount,Type:Config.PrivateZone}' --output table 2>/dev/null)
-        
-        if [[ -n "$ZONES_OUTPUT" ]]; then
-          echo "$ZONES_OUTPUT"
-        else
-          # Fallback to simple text output
-          dokku_log_info1 "Available zones:"
-          run_aws_command route53 list-hosted-zones --query 'HostedZones[].Name' --output text 2>/dev/null | tr '\t' '\n' | sed 's/^/  /' || dokku_log_info1 "  No hosted zones found"
+        if [[ "$VERBOSE" == "true" ]]; then
+          echo
+          dokku_log_info1 "Hosted Zones Discovery:"
+
+          # Show available hosted zones in a nice format
+          local ZONES_OUTPUT
+          ZONES_OUTPUT=$(run_aws_command route53 list-hosted-zones --query 'HostedZones[].{Zone:Name,ID:Id,Records:ResourceRecordSetCount,Type:Config.PrivateZone}' --output table 2>/dev/null)
+
+          if [[ -n "$ZONES_OUTPUT" ]]; then
+            echo "$ZONES_OUTPUT"
+          else
+            # Fallback to simple text output
+            dokku_log_info1 "Available zones:"
+            run_aws_command route53 list-hosted-zones --query 'HostedZones[].Name' --output text 2>/dev/null | tr '\t' '\n' | sed 's/^/  /' || dokku_log_info1 "  No hosted zones found"
+          fi
+
+          echo
+          # Show existing DNS records for Dokku domains
+          dokku_log_info1 "Dokku DNS Records Discovery:"
+          if init_provider_system >/dev/null 2>&1; then
+            # Use the adapter system to discover existing domains
+            dokku_log_info1 "  DNS discovery available through adapter system"
+          else
+            dokku_log_info1 "  No existing Dokku DNS records found"
+          fi
         fi
-        
-        echo
-        # Show existing DNS records for Dokku domains
-        dokku_log_info1 "Dokku DNS Records Discovery:"
-        if init_provider_system >/dev/null 2>&1; then
-          # Use the adapter system to discover existing domains
-          dokku_log_info1 "  DNS discovery available through adapter system"
-        else
-          dokku_log_info1 "  No existing Dokku DNS records found"
-        fi
+        return 0  # AWS verification successful
       else
-        echo
-        dokku_log_fail "Route53 access failed. Please ensure your AWS credentials have the following permissions:
+        if [[ "$VERBOSE" == "true" ]]; then
+          echo
+          dokku_log_fail "Route53 access failed. Please ensure your AWS credentials have the following permissions:
 
 Required AWS Route53 Permissions:
   - route53:ListHostedZones        (list available DNS zones)
@@ -401,41 +477,60 @@ Policy JSON example:
         }
     ]
 }"
+        fi
+        return 1
       fi
       ;;
 
     cloudflare)
-      dokku_log_info1 "Cloudflare API Token Detection:"
-      dokku_log_info1 "  ✓ CLOUDFLARE_API_TOKEN: configured"
-
-      echo
-
-      # Test Cloudflare API connectivity
-      dokku_log_info1 "Testing Cloudflare API Access:"
+      if [[ "$VERBOSE" == "true" ]]; then
+        dokku_log_info1 "Cloudflare API Token Detection:"
+        dokku_log_info1 "  ✓ CLOUDFLARE_API_TOKEN: configured"
+        echo
+        dokku_log_info1 "Testing Cloudflare API Access:"
+      fi
 
       # Call provider validation function
       if provider_validate_credentials >/dev/null 2>&1; then
-        dokku_log_info1 "  ✓ API Authentication: successful"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ✓ API Authentication: successful"
 
         # Test zone listing
         if provider_list_zones >/dev/null 2>&1; then
-          local zone_count
+          local zone_count zone_list
           zone_count=$(provider_list_zones 2>/dev/null | wc -l)
-          dokku_log_info1 "  ✓ Zone Access: can list zones ($zone_count zone(s) available)"
+          zone_list=$(provider_list_zones 2>/dev/null)
 
-          # Show available zones
-          if [[ $zone_count -gt 0 ]]; then
-            echo
-            dokku_log_info1 "Available Cloudflare Zones:"
-            provider_list_zones 2>/dev/null | sed 's/^/  /'
+          # Collect summary data
+          PROVIDER_SUMMARY_ZONE_COUNT="$zone_count"
+          if [[ -n "$zone_list" ]]; then
+            IFS=$'\n' read -r -d '' -a PROVIDER_SUMMARY_ZONES <<< "$zone_list" || true
+          fi
+          PROVIDER_SUMMARY_STATUS="success"
+
+          if [[ "$VERBOSE" == "true" ]]; then
+            dokku_log_info1 "  ✓ Zone Access: can list zones ($zone_count zone(s) available)"
+
+            # Show available zones
+            if [[ $zone_count -gt 0 ]]; then
+              echo
+              dokku_log_info1 "Available Cloudflare Zones:"
+              while IFS= read -r zone; do
+                echo "  $zone"
+              done <<< "$zone_list"
+            fi
           fi
         else
-          dokku_log_info1 "  ⚠ Zone Access: limited (check token permissions)"
+          PROVIDER_SUMMARY_STATUS="partial"
+          PROVIDER_SUMMARY_ERROR="limited zone access"
+          [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ⚠ Zone Access: limited (check token permissions)"
         fi
       else
-        dokku_log_info1 "  ✗ API Authentication: failed"
-        echo
-        dokku_log_warn "Cloudflare API authentication failed. Please check your API token.
+        PROVIDER_SUMMARY_STATUS="failed"
+        PROVIDER_SUMMARY_ERROR="authentication failed"
+        if [[ "$VERBOSE" == "true" ]]; then
+          dokku_log_info1 "  ✗ API Authentication: failed"
+          echo
+          dokku_log_warn "Cloudflare API authentication failed. Please check your API token.
 
 Troubleshooting:
 1. Verify your API token is correct
@@ -443,42 +538,60 @@ Troubleshooting:
 3. Ensure the token hasn't expired
 
 Get a new token from: https://dash.cloudflare.com/profile/api-tokens"
+        fi
         return 1
       fi
       ;;
 
     digitalocean)
-      dokku_log_info1 "DigitalOcean API Token Detection:"
-      dokku_log_info1 "  ✓ DIGITALOCEAN_ACCESS_TOKEN: configured"
-
-      echo
-
-      # Test DigitalOcean API connectivity
-      dokku_log_info1 "Testing DigitalOcean API Access:"
+      if [[ "$VERBOSE" == "true" ]]; then
+        dokku_log_info1 "DigitalOcean API Token Detection:"
+        dokku_log_info1 "  ✓ DIGITALOCEAN_ACCESS_TOKEN: configured"
+        echo
+        dokku_log_info1 "Testing DigitalOcean API Access:"
+      fi
 
       # Call provider validation function
       if provider_validate_credentials >/dev/null 2>&1; then
-        dokku_log_info1 "  ✓ API Authentication: successful"
+        [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ✓ API Authentication: successful"
 
         # Test domain listing
         if provider_list_zones >/dev/null 2>&1; then
-          local domain_count
+          local domain_count domain_list
           domain_count=$(provider_list_zones 2>/dev/null | wc -l)
-          dokku_log_info1 "  ✓ Domain Access: can list domains ($domain_count domain(s) available)"
+          domain_list=$(provider_list_zones 2>/dev/null)
 
-          # Show available domains
-          if [[ $domain_count -gt 0 ]]; then
-            echo
-            dokku_log_info1 "Available DigitalOcean Domains:"
-            provider_list_zones 2>/dev/null | sed 's/^/  /'
+          # Collect summary data
+          PROVIDER_SUMMARY_ZONE_COUNT="$domain_count"
+          if [[ -n "$domain_list" ]]; then
+            IFS=$'\n' read -r -d '' -a PROVIDER_SUMMARY_ZONES <<< "$domain_list" || true
+          fi
+          PROVIDER_SUMMARY_STATUS="success"
+
+          if [[ "$VERBOSE" == "true" ]]; then
+            dokku_log_info1 "  ✓ Domain Access: can list domains ($domain_count domain(s) available)"
+
+            # Show available domains
+            if [[ $domain_count -gt 0 ]]; then
+              echo
+              dokku_log_info1 "Available DigitalOcean Domains:"
+              while IFS= read -r domain; do
+                echo "  $domain"
+              done <<< "$domain_list"
+            fi
           fi
         else
-          dokku_log_info1 "  ⚠ Domain Access: limited (check token permissions)"
+          PROVIDER_SUMMARY_STATUS="partial"
+          PROVIDER_SUMMARY_ERROR="limited domain access"
+          [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "  ⚠ Domain Access: limited (check token permissions)"
         fi
       else
-        dokku_log_info1 "  ✗ API Authentication: failed"
-        echo
-        dokku_log_warn "DigitalOcean API authentication failed. Please check your API token.
+        PROVIDER_SUMMARY_STATUS="failed"
+        PROVIDER_SUMMARY_ERROR="authentication failed"
+        if [[ "$VERBOSE" == "true" ]]; then
+          dokku_log_info1 "  ✗ API Authentication: failed"
+          echo
+          dokku_log_warn "DigitalOcean API authentication failed. Please check your API token.
 
 Troubleshooting:
 1. Verify your API token is correct
@@ -486,28 +599,47 @@ Troubleshooting:
 3. Ensure the token hasn't been revoked
 
 Get a new token from: https://cloud.digitalocean.com/account/api/tokens"
+        fi
         return 1
       fi
       ;;
 
     template)
-      dokku_log_info1 "Template Provider Testing:"
-      dokku_log_info1 "  ✓ Template provider: available for testing"
-      echo
-      dokku_log_info1 "Template provider verification shows basic functionality."
-      dokku_log_info1 "This is a test provider for development and testing purposes."
+      PROVIDER_SUMMARY_STATUS="success"
+      PROVIDER_SUMMARY_ZONE_COUNT=0
+      if [[ "$VERBOSE" == "true" ]]; then
+        dokku_log_info1 "Template Provider Testing:"
+        dokku_log_info1 "  ✓ Template provider: available for testing"
+        echo
+        dokku_log_info1 "Template provider verification shows basic functionality."
+        dokku_log_info1 "This is a test provider for development and testing purposes."
+      fi
       ;;
 
     mock)
-      dokku_log_info1 "Mock Provider Testing:"
       if [[ -n "${MOCK_API_KEY:-}" ]]; then
-        dokku_log_info1 "  ✓ MOCK_API_KEY: configured"
+        PROVIDER_SUMMARY_STATUS="success"
+        PROVIDER_SUMMARY_ZONE_COUNT=0
+        if [[ "$VERBOSE" == "true" ]]; then
+          dokku_log_info1 "Mock Provider Testing:"
+          dokku_log_info1 "  ✓ MOCK_API_KEY: configured"
+          echo
+          dokku_log_info1 "Mock provider verification shows basic functionality."
+          dokku_log_info1 "This is a test provider for development and testing purposes."
+        fi
+        return 0
       else
-        dokku_log_info1 "  ✗ MOCK_API_KEY: not set"
+        PROVIDER_SUMMARY_STATUS="failed"
+        PROVIDER_SUMMARY_ERROR="MOCK_API_KEY not set"
+        if [[ "$VERBOSE" == "true" ]]; then
+          dokku_log_info1 "Mock Provider Testing:"
+          dokku_log_info1 "  ✗ MOCK_API_KEY: not set"
+          echo
+          dokku_log_info1 "Mock provider verification shows basic functionality."
+          dokku_log_info1 "This is a test provider for development and testing purposes."
+        fi
+        return 1
       fi
-      echo
-      dokku_log_info1 "Mock provider verification shows basic functionality."
-      dokku_log_info1 "This is a test provider for development and testing purposes."
       ;;
 
     *)
@@ -515,18 +647,119 @@ Get a new token from: https://cloud.digitalocean.com/account/api/tokens"
       ;;
     esac
 
-    echo
-    dokku_log_info1 "$provider_name provider verification complete"
+    [[ "$VERBOSE" == "true" ]] && echo
+    [[ "$VERBOSE" == "true" ]] && dokku_log_info1 "$provider_name provider verification complete"
   }
+
+  # Arrays to collect summary data from all providers
+  declare -a SUMMARY_PROVIDERS=()
+  declare -a SUMMARY_STATUSES=()
+  declare -a SUMMARY_ZONE_COUNTS=()
+  declare -a SUMMARY_ZONES_LISTS=()
+  declare -a SUMMARY_ERRORS=()
 
   # Verify each provider
   local verification_success=false
+  if [[ "$VERBOSE" != "true" ]]; then
+    dokku_log_info2 "Checking DNS providers..."
+    echo
+  fi
+
   for provider in "${PROVIDERS_TO_VERIFY[@]}"; do
     if verify_provider "$provider"; then
       verification_success=true
     fi
-    echo
+
+    # Collect summary data
+    SUMMARY_PROVIDERS+=("$PROVIDER_SUMMARY_NAME")
+    SUMMARY_STATUSES+=("$PROVIDER_SUMMARY_STATUS")
+    SUMMARY_ZONE_COUNTS+=("$PROVIDER_SUMMARY_ZONE_COUNT")
+    SUMMARY_ERRORS+=("$PROVIDER_SUMMARY_ERROR")
+
+    # Store zone list as comma-separated string
+    local zones_str=""
+    if [[ ${#PROVIDER_SUMMARY_ZONES[@]} -gt 0 ]]; then
+      zones_str=$(printf "%s," "${PROVIDER_SUMMARY_ZONES[@]}")
+      zones_str="${zones_str%,}"  # Remove trailing comma
+    fi
+    SUMMARY_ZONES_LISTS+=("$zones_str")
+
+    [[ "$VERBOSE" == "true" ]] && echo
   done
+
+  # Display summary if not in verbose mode
+  if [[ "$VERBOSE" != "true" ]]; then
+    for i in "${!SUMMARY_PROVIDERS[@]}"; do
+      local provider="${SUMMARY_PROVIDERS[$i]}"
+      local status="${SUMMARY_STATUSES[$i]}"
+      local zone_count="${SUMMARY_ZONE_COUNTS[$i]}"
+      local error="${SUMMARY_ERRORS[$i]}"
+      local zones="${SUMMARY_ZONES_LISTS[$i]}"
+
+      # Format status symbol
+      local status_symbol
+      case "$status" in
+        success)
+          status_symbol="✓"
+          ;;
+        failed)
+          status_symbol="✗"
+          ;;
+        partial)
+          status_symbol="⚠"
+          ;;
+        *)
+          status_symbol="?"
+          ;;
+      esac
+
+      # Build summary line
+      local summary_line="  $status_symbol $provider:"
+
+      if [[ "$status" == "success" ]]; then
+        if [[ "$zone_count" -eq 0 ]]; then
+          summary_line="$summary_line no zones"
+        elif [[ "$zone_count" -eq 1 ]]; then
+          # Show zone name for single zone
+          summary_line="$summary_line 1 zone"
+          if [[ -n "$zones" ]]; then
+            summary_line="$summary_line ($zones)"
+          fi
+        else
+          # Show zone count and first few zones for multiple
+          summary_line="$summary_line $zone_count zones"
+          if [[ -n "$zones" ]]; then
+            # Convert comma-separated to array and show first 3
+            IFS=',' read -r -a zone_array <<< "$zones"
+            local display_zones="${zone_array[0]}"
+            if [[ ${#zone_array[@]} -gt 1 ]]; then
+              display_zones="$display_zones, ${zone_array[1]}"
+            fi
+            if [[ ${#zone_array[@]} -gt 2 ]]; then
+              if [[ ${#zone_array[@]} -gt 3 ]]; then
+                display_zones="$display_zones, ... (+$((${#zone_array[@]} - 2)) more)"
+              else
+                display_zones="$display_zones, ${zone_array[2]}"
+              fi
+            fi
+            summary_line="$summary_line ($display_zones)"
+          fi
+        fi
+      else
+        # Failed or partial - show error
+        if [[ -n "$error" ]]; then
+          summary_line="$summary_line $error"
+        else
+          summary_line="$summary_line verification failed"
+        fi
+      fi
+
+      echo "$summary_line"
+    done
+
+    echo
+    echo "Use --verbose for detailed information"
+  fi
 
   # If no providers were successfully verified, that's an error
   if [[ "$verification_success" != "true" ]]; then

--- a/subcommands/providers:verify
+++ b/subcommands/providers:verify
@@ -614,6 +614,7 @@ Get a new token from: https://cloud.digitalocean.com/account/api/tokens"
         dokku_log_info1 "Template provider verification shows basic functionality."
         dokku_log_info1 "This is a test provider for development and testing purposes."
       fi
+      return 0
       ;;
 
     mock)

--- a/tests/integration/providers-integration.bats
+++ b/tests/integration/providers-integration.bats
@@ -26,9 +26,15 @@ setup() {
 }
 
 @test "(dns:providers:verify) shows installation instructions when AWS CLI not available" {
-  run dokku dns:providers:verify
-  # Should show AWS CLI installation instructions when not available
+  run dokku dns:providers:verify --verbose
+  # Should show AWS CLI installation instructions when not available (in verbose mode)
   [[ "$output" =~ (AWS\ CLI\ is\ not\ installed|Please\ install\ it\ first) ]]
+}
+
+@test "(dns:providers:verify) shows error in summary when AWS CLI not available" {
+  run dokku dns:providers:verify
+  # Should show error in summary mode when AWS CLI not available
+  [[ "$output" =~ (aws:.*AWS\ CLI\ not\ installed|No\ providers\ could\ be\ verified) ]]
 }
 
 @test "(providers) cloudflare provider is available in the system" {


### PR DESCRIPTION
## Summary

Adds `--verbose` flag to `dns:providers:verify` command to control output detail level, making the default output concise and scalable for multiple providers.

## Changes

### Default (Summary) Mode
- Shows one-line status per provider
- Format: `✓ provider: N zones (zone1, zone2, ...)`
- Scales well with 1-5+ providers
- Displays helpful hint: "Use --verbose for detailed information"

### Verbose Mode (`--verbose` or `-v`)
- Shows full detailed output (previous default behavior)
- Includes credential detection, API testing, zone tables
- Useful for troubleshooting and initial setup

## Implementation Details

1. **Flag Parsing**: Added `--verbose/-v` flag support
2. **Helper Functions**: Created conditional output helpers:
   - `verbose_log_info1()` - Shows info1 only in verbose mode
   - `verbose_log_info2()` - Shows info2 only in verbose mode  
   - `verbose_echo()` - Shows blank line only in verbose mode
3. **Summary Collection**: Track provider status, zone count, zone names during verification
4. **Intelligent Display**: Show first 2-3 zones, then "+N more" for many zones
5. **Status Symbols**: ✓ (success), ✗ (failed), ⚠ (partial)

## Output Comparison

### Before (verbose, ~56 lines per provider):
```
=====> Checking Dependencies
----->   jq: available (jq-1.6)

=====> Auto-detected provider: AWS Route53

=====> Verifying aws provider
-----> Current Configuration:
----->   DNS Provider: aws
=====> AWS Route53 Setup
----->   AWS CLI: installed (aws-cli/2.27.58)
-----> Credential Detection:
----->   ✗ Environment variables: not set
----->   YES AWS config files: ~/.aws/credentials, ~/.aws/config
----->   ✗ IAM Role: not available
[... 40+ more lines ...]
```

### After (summary, ~5 lines total):
```
=====> Checking DNS providers...

  ✓ aws: 2 zones (dean.is., deanoftech.com.)
  ✓ cloudflare: 5 zones (example.com, test.com, ... (+3 more))
  ✗ digitalocean: authentication failed

Use --verbose for detailed information

-----> DNS Provider Verification Complete
```

## Testing

- ✅ Summary mode with single provider (aws)
- ✅ Summary mode with multiple providers (aws, mock, template)
- ✅ Verbose mode shows full details as before
- ✅ Specific provider verification (providers:verify aws)
- ✅ Failed provider shows error in summary
- ✅ Zone count and names displayed correctly
- ✅ Shellcheck linting passes

## Impact

- 🎯 **Scalability**: Output scales to 1-5+ providers without becoming overwhelming
- 📊 **Clarity**: Quick scanning of provider status at a glance
- 🔍 **Flexibility**: Detailed output still available with --verbose
- 🚀 **Performance**: No change - verification still runs same checks
- 📝 **Usability**: Cleaner output for regular use, details when needed

## Related

Part of Phase 28: Display and Reporting Fixes (Pre-Release)

Addresses issue where `dns:providers:verify` output was excessively verbose and did not scale well to multiple providers.