### PR TITLE
Document Phase 26c completion and remove Phase 29 from TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,19 +3,6 @@
 The DNS plugin is in progress! Many core features have been implemented and tested. See [DONE.md](./DONE.md) for completed work.
 
 
-### Phase 29: Trigger System Improvements (Pre-Release)
-
-**Objective:** Fix post-create trigger failing to detect auto-added domains from global vhost.
-
-- [ ] **Fix Post-Create Trigger Domain Detection**
-  - [ ] post-create trigger says "No domains configured" but domain exists
-  - [ ] Trigger doesn't detect auto-added domain from global vhost
-  - [ ] Fix is_domain_in_enabled_zone function or post-create timing
-  - [ ] Test: my-test-app.deanoftech.com should be detected in enabled deanoftech.com zone
-  - **Problem:** Trigger runs before domain is fully configured
-  - **Reference:** See `test-output-examples/app-create-trigger-fail.txt`
-
-
 ### Phase 30: Zone Management UX Improvements (Pre-Release)
 
 **Objective:** Improve user experience for zone management with better output and new sync command.


### PR DESCRIPTION
## Summary

Phase 29 (fix post-create trigger domain detection) was already completed in Phase 26c (PR #56, commit 5a0f11d) but was not properly documented. This PR updates the documentation to reflect that work.

## Changes

### Added to DONE.md
- **Phase 26c: Fix Post-Create Trigger Domain Detection** - Complete documentation of the post-create hook improvements
  - Problem: Trigger ran before Dokku assigned default domain from global vhost
  - Solution: Predict the default domain and automatically enable DNS if in an enabled zone  
  - Implementation details with code examples
  - Testing and impact summary

### Removed from TODO.md
- **Phase 29: Trigger System Improvements** - Removed since it was already completed in Phase 26c

## How Phase 26c Works

The post-create hook now:
1. Predicts the default domain: `{app}.{global-vhost}` (e.g., `my-test-app.deanoftech.com`)
2. Checks if predicted domain is in an enabled zone
3. Automatically adds app to DNS management and syncs if in enabled zone

**Example:**
```bash
$ dokku apps:create my-test-app
-----> Creating my-test-app...
-----> DNS: Predicted domain 'my-test-app.deanoftech.com' is in an enabled zone
-----> DNS: Record for 'my-test-app.deanoftech.com' created successfully
```

## Impact

- ✅ Apps get DNS records immediately upon creation (if zone enabled)
- ✅ No manual `dns:apps:enable` needed for default domains
- ✅ Only auto-enables if domain is in an enabled zone
- ✅ Backward compatible with `domains-add` trigger

## Testing

No code changes in this PR - only documentation updates. The functionality has been working correctly since PR #56 was merged.

## Related

- Original PR: #56 (Phase 26c implementation)
- TODO item: Phase 29 (now removed, was duplicate)