### PR TITLE
Phase 30: Zone Management UX Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ dns:version                                        # show DNS plugin version and
 dns:zones [<zone>]                                 # list DNS zones and their auto-discovery status
 dns:zones:disable <zone>                           # disable DNS zone and remove managed domains
 dns:zones:enable <zone>                            # enable DNS zone for automatic app domain management
+dns:zones:sync <zone>                              # synchronize DNS records for apps within a zone
 dns:zones:ttl <zone>                               # get or set TTL (time-to-live) for a DNS zone in seconds
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,25 +3,6 @@
 The DNS plugin is in progress! Many core features have been implemented and tested. See [DONE.md](./DONE.md) for completed work.
 
 
-### Phase 30: Zone Management UX Improvements (Pre-Release)
-
-**Objective:** Improve user experience for zone management with better output and new sync command.
-
-- [ ] **Improve Zone Enable Output**
-  - [ ] Output copy-pastable commands when enabling a zone
-  - [ ] Show `dokku dns:apps:enable <app>` commands with domain as comment
-  - [ ] Format: `dokku dns:apps:enable myapp  # example.com`
-  - [ ] Group by app to avoid duplicate commands
-  - **Goal:** Make it easier for users to enable apps after enabling zones
-
-- [ ] **Add zones:sync Command**
-  - [ ] Create `dns:zones:sync [zone]` subcommand
-  - [ ] Sync all apps/domains within a specific zone
-  - [ ] If zone parameter omitted, sync all enabled zones
-  - [ ] Show progress per domain within the zone
-  - **Goal:** Bulk sync operations at the zone level
-
-
 ### Phase 36: Pre-Release Testing & Validation
 
 - [ ] **Create Testing Documentation**

--- a/help-functions
+++ b/help-functions
@@ -28,7 +28,7 @@ is_implemented_command() {
 
   # All our subcommands are implemented
   case "$SUBCOMMAND" in
-    cron | help | report | sync-all | sync:deletions | version | zones | zones:enable | zones:disable | zones:ttl | providers:verify | apps | apps:enable | apps:disable | apps:sync | apps:report | triggers | triggers:enable | triggers:disable)
+    cron | help | report | sync-all | sync:deletions | version | zones | zones:enable | zones:disable | zones:sync | zones:ttl | providers:verify | apps | apps:enable | apps:disable | apps:sync | apps:report | triggers | triggers:enable | triggers:disable)
       return 0
       ;;
     *)

--- a/subcommands/zones:enable
+++ b/subcommands/zones:enable
@@ -27,6 +27,143 @@ fi
 
 source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
 
+# Check if a domain belongs to a specific zone
+# Usage: is_domain_in_zone <domain> <zone>
+# Returns: 0 if domain is in zone, 1 if not
+is_domain_in_zone() {
+  local DOMAIN="$1"
+  local ZONE="$2"
+
+  # Check if domain matches this zone exactly or is a subdomain
+  if [[ "$DOMAIN" == "$ZONE" ]] || [[ "$DOMAIN" == *".$ZONE" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Show suggested next steps after enabling a zone
+# Usage: show_zone_enable_next_steps <zone>
+show_zone_enable_next_steps() {
+  local ZONE="$1"
+
+  # Get all apps
+  local apps
+  if ! command -v dokku >/dev/null 2>&1; then
+    return 0  # Skip if dokku command not available
+  fi
+
+  apps=$(dokku apps:list 2>/dev/null | tail -n +2 || echo "")
+
+  if [[ -z "$apps" ]]; then
+    return 0  # No apps to check
+  fi
+
+  # Build a map of app -> domains in this zone
+  declare -A app_domains_map
+  local found_any=false
+
+  while IFS= read -r app; do
+    [[ -z "$app" ]] && continue
+
+    # Get domains for this app
+    local domains
+    domains=$(get_app_domains "$app" 2>/dev/null || echo "")
+
+    # Find domains that are in this zone
+    local zone_domains=()
+    while IFS= read -r domain; do
+      [[ -z "$domain" ]] && continue
+
+      if is_domain_in_zone "$domain" "$ZONE"; then
+        zone_domains+=("$domain")
+        found_any=true
+      fi
+    done <<< "$domains"
+
+    # Store domains for this app if any found
+    if [[ ${#zone_domains[@]} -gt 0 ]]; then
+      app_domains_map["$app"]="${zone_domains[*]}"
+    fi
+  done <<< "$apps"
+
+  # Display suggestions if we found any apps with domains in this zone
+  if [[ "$found_any" == "true" ]]; then
+    echo
+    dokku_log_info1 "Next steps - enable DNS management for apps with domains in this zone:"
+    echo
+
+    for app in "${!app_domains_map[@]}"; do
+      local domains="${app_domains_map[$app]}"
+      # Convert space-separated domains to comma-separated for comment
+      local domain_comment="${domains// /, }"
+      echo "  dokku dns:apps:enable $app  # $domain_comment"
+    done
+
+    echo
+  fi
+}
+
+# Show suggested next steps for all enabled zones
+# Usage: show_all_zones_enable_next_steps
+show_all_zones_enable_next_steps() {
+  # Get all apps
+  local apps
+  if ! command -v dokku >/dev/null 2>&1; then
+    return 0  # Skip if dokku command not available
+  fi
+
+  apps=$(dokku apps:list 2>/dev/null | tail -n +2 || echo "")
+
+  if [[ -z "$apps" ]]; then
+    return 0  # No apps to check
+  fi
+
+  # Build a map of app -> domains in any enabled zone
+  declare -A app_domains_map
+  local found_any=false
+
+  while IFS= read -r app; do
+    [[ -z "$app" ]] && continue
+
+    # Get domains for this app
+    local domains
+    domains=$(get_app_domains "$app" 2>/dev/null || echo "")
+
+    # Find domains that are in any enabled zone
+    local zone_domains=()
+    while IFS= read -r domain; do
+      [[ -z "$domain" ]] && continue
+
+      if is_domain_in_enabled_zone "$domain"; then
+        zone_domains+=("$domain")
+        found_any=true
+      fi
+    done <<< "$domains"
+
+    # Store domains for this app if any found
+    if [[ ${#zone_domains[@]} -gt 0 ]]; then
+      app_domains_map["$app"]="${zone_domains[*]}"
+    fi
+  done <<< "$apps"
+
+  # Display suggestions if we found any apps with domains in enabled zones
+  if [[ "$found_any" == "true" ]]; then
+    echo
+    dokku_log_info1 "Next steps - enable DNS management for apps with domains in enabled zones:"
+    echo
+
+    for app in "${!app_domains_map[@]}"; do
+      local domains="${app_domains_map[$app]}"
+      # Convert space-separated domains to comma-separated for comment
+      local domain_comment="${domains// /, }"
+      echo "  dokku dns:apps:enable $app  # $domain_comment"
+    done
+
+    echo
+  fi
+}
+
 service-zones-enable-cmd() {
   #E enable DNS zone for automatic app domain management
   #E dokku $PLUGIN_COMMAND_PREFIX:zones:enable example.com
@@ -112,8 +249,11 @@ zones_add_zone() {
   
   # Mark zone as enabled for auto-discovery
   zones_set_enabled "$ZONE"
-  
+
   dokku_log_info1 "Zone '$ZONE' added to auto-discovery"
+
+  # Show suggested next steps for apps with domains in this zone
+  show_zone_enable_next_steps "$ZONE"
 }
 
 zones_add_all() {
@@ -144,13 +284,16 @@ zones_add_all() {
   for zone in $ZONES; do
     dokku_log_info1 "Adding zone: $zone"
     zones_processed=$((zones_processed + 1))
-    
+
     # Add this zone to auto-discovery
     zones_set_enabled "$zone"
     echo
   done
-  
+
   dokku_log_info1 "Zones added to auto-discovery: $zones_processed"
+
+  # Show suggested next steps for all apps with domains in enabled zones
+  show_all_zones_enable_next_steps
 }
 
 service-zones-enable-cmd "$@"

--- a/subcommands/zones:sync
+++ b/subcommands/zones:sync
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail
+[[ $DOKKU_TRACE ]] && set -x
+
+# Load dokku functions if available
+if [[ -f "$PLUGIN_CORE_AVAILABLE_PATH/common/functions" ]]; then
+  source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
+fi
+
+# Define missing functions if needed
+if ! declare -f dokku_log_info1 >/dev/null 2>&1; then
+  dokku_log_info1() { echo "-----> $*"; }
+fi
+
+if ! declare -f dokku_log_info2 >/dev/null 2>&1; then
+  dokku_log_info2() { echo "=====> $*"; }
+fi
+
+if ! declare -f dokku_log_warn >/dev/null 2>&1; then
+  dokku_log_warn() { echo " !     $*"; }
+fi
+
+if ! declare -f dokku_log_fail >/dev/null 2>&1; then
+  dokku_log_fail() { echo " !     $*" >&2; exit 1; }
+fi
+
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
+
+# Check if a domain belongs to a specific zone
+# Usage: is_domain_in_zone <domain> <zone>
+# Returns: 0 if domain is in zone, 1 if not
+is_domain_in_zone() {
+  local DOMAIN="$1"
+  local ZONE="$2"
+
+  # Check if domain matches this zone exactly or is a subdomain
+  if [[ "$DOMAIN" == "$ZONE" ]] || [[ "$DOMAIN" == *".$ZONE" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Get list of enabled zones
+# Usage: get_enabled_zones
+# Returns: newline-separated list of enabled zone names
+get_enabled_zones() {
+  local ENABLED_ZONES_FILE="$PLUGIN_DATA_ROOT/ENABLED_ZONES"
+
+  if [[ -f "$ENABLED_ZONES_FILE" ]] && [[ -s "$ENABLED_ZONES_FILE" ]]; then
+    cat "$ENABLED_ZONES_FILE"
+  fi
+}
+
+# Sync all apps with domains in a specific zone
+# Usage: sync_zone <zone>
+sync_zone() {
+  local ZONE="$1"
+
+  # Verify zone is enabled
+  local ENABLED_ZONES_FILE="$PLUGIN_DATA_ROOT/ENABLED_ZONES"
+  if [[ ! -f "$ENABLED_ZONES_FILE" ]] || ! grep -q "^$ZONE$" "$ENABLED_ZONES_FILE"; then
+    dokku_log_fail "Zone '$ZONE' is not enabled. Enable it first: dokku $PLUGIN_COMMAND_PREFIX:zones:enable $ZONE"
+  fi
+
+  dokku_log_info2 "Syncing DNS records for zone: $ZONE"
+  echo
+
+  # Get all apps
+  local apps
+  if ! command -v dokku >/dev/null 2>&1; then
+    dokku_log_fail "dokku command not available"
+  fi
+
+  apps=$(dokku apps:list 2>/dev/null | tail -n +2 || echo "")
+
+  if [[ -z "$apps" ]]; then
+    dokku_log_info1 "No apps found"
+    return 0
+  fi
+
+  # Find apps with domains in this zone
+  local apps_to_sync=()
+  local app_domain_map=()
+
+  while IFS= read -r app; do
+    [[ -z "$app" ]] && continue
+
+    # Get domains for this app
+    local domains
+    domains=$(get_app_domains "$app" 2>/dev/null || echo "")
+
+    # Find domains that are in this zone
+    local zone_domains=()
+    while IFS= read -r domain; do
+      [[ -z "$domain" ]] && continue
+
+      if is_domain_in_zone "$domain" "$ZONE"; then
+        zone_domains+=("$domain")
+      fi
+    done <<< "$domains"
+
+    # Store apps with domains in this zone
+    if [[ ${#zone_domains[@]} -gt 0 ]]; then
+      apps_to_sync+=("$app")
+      app_domain_map+=("$app:${zone_domains[*]}")
+    fi
+  done <<< "$apps"
+
+  if [[ ${#apps_to_sync[@]} -eq 0 ]]; then
+    dokku_log_info1 "No apps found with domains in zone '$ZONE'"
+    return 0
+  fi
+
+  dokku_log_info1 "Found ${#apps_to_sync[@]} app(s) with domains in this zone"
+  echo
+
+  # Sync each app
+  local success_count=0
+  local fail_count=0
+
+  for app in "${apps_to_sync[@]}"; do
+    # Find domains for this app from the map
+    local app_domains=""
+    for entry in "${app_domain_map[@]}"; do
+      if [[ "$entry" == "$app:"* ]]; then
+        app_domains="${entry#*:}"
+        break
+      fi
+    done
+
+    dokku_log_info1 "Syncing app: $app"
+    dokku_log_info2 "Domains: ${app_domains// /, }"
+
+    # Sync the app using dns_app function from functions file
+    if dns_app "$app"; then
+      success_count=$((success_count + 1))
+      dokku_log_info1 "✓ Successfully synced: $app"
+    else
+      fail_count=$((fail_count + 1))
+      dokku_log_warn "✗ Failed to sync: $app"
+    fi
+    echo
+  done
+
+  # Summary
+  dokku_log_info2 "Zone Sync Summary for: $ZONE"
+  dokku_log_info1 "Successfully synced: $success_count app(s)"
+
+  if [[ $fail_count -gt 0 ]]; then
+    dokku_log_warn "Failed to sync: $fail_count app(s)"
+    return 1
+  fi
+
+  return 0
+}
+
+# Sync all apps with domains in all enabled zones
+# Usage: sync_all_zones
+sync_all_zones() {
+  local enabled_zones
+  enabled_zones=$(get_enabled_zones)
+
+  if [[ -z "$enabled_zones" ]]; then
+    dokku_log_fail "No zones are enabled. Enable zones first: dokku $PLUGIN_COMMAND_PREFIX:zones:enable <zone>"
+  fi
+
+  # Count enabled zones
+  local zone_count
+  zone_count=$(echo "$enabled_zones" | wc -l)
+
+  dokku_log_info2 "Syncing DNS records for all enabled zones ($zone_count zone(s))"
+  echo
+
+  # Get all apps
+  local apps
+  if ! command -v dokku >/dev/null 2>&1; then
+    dokku_log_fail "dokku command not available"
+  fi
+
+  apps=$(dokku apps:list 2>/dev/null | tail -n +2 || echo "")
+
+  if [[ -z "$apps" ]]; then
+    dokku_log_info1 "No apps found"
+    return 0
+  fi
+
+  # Find apps with domains in any enabled zone
+  local apps_to_sync=()
+  declare -A app_domains_map
+
+  while IFS= read -r app; do
+    [[ -z "$app" ]] && continue
+
+    # Get domains for this app
+    local domains
+    domains=$(get_app_domains "$app" 2>/dev/null || echo "")
+
+    # Find domains that are in any enabled zone
+    local zone_domains=()
+    while IFS= read -r domain; do
+      [[ -z "$domain" ]] && continue
+
+      if is_domain_in_enabled_zone "$domain"; then
+        zone_domains+=("$domain")
+      fi
+    done <<< "$domains"
+
+    # Store apps with domains in enabled zones
+    if [[ ${#zone_domains[@]} -gt 0 ]]; then
+      apps_to_sync+=("$app")
+      app_domains_map["$app"]="${zone_domains[*]}"
+    fi
+  done <<< "$apps"
+
+  if [[ ${#apps_to_sync[@]} -eq 0 ]]; then
+    dokku_log_info1 "No apps found with domains in enabled zones"
+    return 0
+  fi
+
+  dokku_log_info1 "Found ${#apps_to_sync[@]} app(s) with domains in enabled zones"
+  echo
+
+  # Sync each app
+  local success_count=0
+  local fail_count=0
+
+  for app in "${apps_to_sync[@]}"; do
+    local app_domains="${app_domains_map[$app]}"
+
+    dokku_log_info1 "Syncing app: $app"
+    dokku_log_info2 "Domains: ${app_domains// /, }"
+
+    # Sync the app using dns_app function from functions file
+    if dns_app "$app"; then
+      success_count=$((success_count + 1))
+      dokku_log_info1 "✓ Successfully synced: $app"
+    else
+      fail_count=$((fail_count + 1))
+      dokku_log_warn "✗ Failed to sync: $app"
+    fi
+    echo
+  done
+
+  # Summary
+  dokku_log_info2 "All Zones Sync Summary"
+  dokku_log_info1 "Successfully synced: $success_count app(s)"
+
+  if [[ $fail_count -gt 0 ]]; then
+    dokku_log_warn "Failed to sync: $fail_count app(s)"
+    return 1
+  fi
+
+  return 0
+}
+
+service-zones-sync-cmd() {
+  #E synchronize DNS records for apps within a specific zone or all enabled zones
+  #E dokku $PLUGIN_COMMAND_PREFIX:zones:sync [zone]
+  #E sync all apps/domains within the specified zone
+  #E if zone parameter is omitted, sync all apps in all enabled zones
+  #E shows progress per app and domain within the zone
+  #A zone, zone name to sync (optional - omit to sync all enabled zones)
+  declare desc="synchronize DNS records for apps within a zone"
+  local cmd="$PLUGIN_COMMAND_PREFIX:zones:sync" argv=("$@")
+
+  # Handle Dokku command routing - first argument will be the command name
+  if [[ "$1" == "$cmd" ]]; then
+    shift 1
+  fi
+
+  declare ZONE=""
+
+  # Parse optional zone argument
+  if [[ $# -gt 0 ]]; then
+    ZONE="$1"
+  fi
+
+  # Sync based on whether zone was specified
+  if [[ -n "$ZONE" ]]; then
+    sync_zone "$ZONE"
+  else
+    sync_all_zones
+  fi
+}
+
+service-zones-sync-cmd "$@"


### PR DESCRIPTION
## Phase 30: Zone Management UX Improvements

Completes Phase 30 of the pre-release roadmap with two major UX enhancements for zone management.

### Task 1: Improve Zone Enable Output

**Problem**: When users enabled zones, they only saw "Zone added to auto-discovery" with no guidance on next steps.

**Solution**: Show copy-pastable `dokku dns:apps:enable` commands for apps with domains in the zone.

**Example Output**:
```bash
$ dokku dns:zones:enable example.com
=====> Adding zone to auto-discovery: example.com
-----> Zone 'example.com' added to auto-discovery

-----> Next steps - enable DNS management for apps with domains in this zone:

  dokku dns:apps:enable myapp  # example.com, www.example.com
  dokku dns:apps:enable api  # api.example.com
```

**Changes**:
- Added `is_domain_in_zone()` helper function
- Added `show_zone_enable_next_steps()` for single zone suggestions
- Added `show_all_zones_enable_next_steps()` for --all flag
- Enhanced `zones_add_zone()` to display next steps
- Enhanced `zones_add_all()` to show consolidated suggestions

### Task 2: Add zones:sync Command

**Problem**: No way to bulk sync all apps within a specific zone. Users had to sync all apps or individual apps.

**Solution**: New `dns:zones:sync [zone]` command for zone-based bulk operations.

**Features**:
- `dokku dns:zones:sync <zone>` - Sync all apps with domains in specific zone
- `dokku dns:zones:sync` - Sync all apps with domains in all enabled zones
- Shows progress per app with domain list
- Provides success/failure summary

**Example Output**:
```bash
$ dokku dns:zones:sync example.com
=====> Syncing DNS records for zone: example.com

-----> Found 2 app(s) with domains in this zone

-----> Syncing app: myapp
=====> Domains: example.com, www.example.com
[... DNS sync output ...]
-----> ✓ Successfully synced: myapp

=====> Zone Sync Summary for: example.com
-----> Successfully synced: 2 app(s)
```

**Changes**:
- Created `subcommands/zones:sync` with full zone-based sync logic
- Registered command in `help-functions` dispatcher
- Updated `README.md` with new command documentation

## Files Changed

- `subcommands/zones:enable` - Added next steps display (+143 lines)
- `subcommands/zones:sync` - New zone-based sync command (+288 lines)
- `help-functions` - Registered zones:sync command
- `README.md` - Added zones:sync documentation
- `TODO.md` - Removed completed Phase 30
- `DONE.md` - Documented Phase 30 completion

## Testing

- ✅ Linting passes
- ✅ Code follows existing patterns from `sync-all` and `apps:sync`
- ✅ Proper error handling for invalid zones and missing apps
- ✅ Graceful handling when no apps found in zone

## Impact

- 🎯 **Better UX**: Users know exactly what to do after enabling zones
- 📋 **Copy-pastable**: Commands ready to use, reducing errors
- ⚡ **Efficient bulk operations**: Zone-level sync for targeted updates
- 🔍 **Clear progress**: Shows which apps and domains are being synced
- 📊 **Summary reporting**: Clear success/failure counts

## User Journey

```bash
# 1. Enable zone - get suggested next steps
$ dokku dns:zones:enable example.com
[shows copy-pastable dns:apps:enable commands]

# 2. Enable apps as suggested
$ dokku dns:apps:enable myapp

# 3. Sync entire zone at once
$ dokku dns:zones:sync example.com
[syncs all apps with domains in example.com]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)