### PR TITLE
Reduce verbosity of DNS cleanup output on app deletion

### DIFF
--- a/post-delete
+++ b/post-delete
@@ -52,8 +52,6 @@ main() {
     return 0
   fi
 
-  dokku_log_info2 "DNS: Cleaning up DNS management for app '$APP'"
-
   # Get domains that were managed before removal
   local APP_DOMAINS_FILE="$PLUGIN_DATA_ROOT/$APP/DOMAINS"
   local managed_domains=()
@@ -62,13 +60,6 @@ main() {
     while IFS= read -r domain; do
       [[ -n "$domain" ]] && managed_domains+=("$domain")
     done <"$APP_DOMAINS_FILE"
-  fi
-
-  if [[ ${#managed_domains[@]} -gt 0 ]]; then
-    dokku_log_info1 "DNS: Removing DNS management for domains:"
-    for domain in "${managed_domains[@]}"; do
-      dokku_log_info1 "  • $domain"
-    done
   fi
 
   # Remove app from DNS management
@@ -94,11 +85,10 @@ main() {
       echo "$(date '+%Y-%m-%d %H:%M:%S') post-delete $APP $domain" >>"$DELETIONS_QUEUE"
     done
 
-    dokku_log_info1 "DNS: App '$APP' removed from DNS management"
-    dokku_log_info1 "DNS: Domains queued for cleanup: ${managed_domains[*]}"
-    dokku_log_info1 "DNS: Run 'dokku $PLUGIN_COMMAND_PREFIX:sync:deletions' to clean up orphaned DNS records"
+    dokku_log_info1 "DNS: Removed '$APP' from management (${managed_domains[*]})"
+    dokku_log_info1 "     Run 'dokku $PLUGIN_COMMAND_PREFIX:sync:deletions' to clean up orphaned records"
   else
-    dokku_log_info1 "DNS: App '$APP' removed from DNS management (no domains were managed)"
+    dokku_log_info1 "DNS: Removed '$APP' from management (no domains were managed)"
   fi
 }
 

--- a/test-output-examples/destroy-trigger.txt
+++ b/test-output-examples/destroy-trigger.txt
@@ -19,12 +19,8 @@ $ dokku apps:destroy my-test-app
        Unlinking from recipebook
        Unlinking from recipes-db
        Unlinking from nextcloud-redis
-=====> DNS: Cleaning up DNS management for app 'my-test-app'
------> DNS: Removing DNS management for domains:
------>   • my-test-app.deanoftech.com
------> DNS: App 'my-test-app' removed from DNS management
------> DNS: Domains queued for cleanup: my-test-app.deanoftech.com
------> DNS: Run 'dokku dns:sync:deletions' to clean up orphaned DNS records
+-----> DNS: Removed 'my-test-app' from management (my-test-app.deanoftech.com)
+       Run 'dokku dns:sync:deletions' to clean up orphaned records
 -----> Updated schedule file
 -----> Cleaning up...
 -----> Retiring old containers and images

--- a/tests/dns_triggers.bats
+++ b/tests/dns_triggers.bats
@@ -195,8 +195,8 @@ teardown() {
 
   run "$PLUGIN_ROOT/post-delete" "test-app"
   assert_success
-  assert_output_contains "DNS: Cleaning up DNS management for app 'test-app'"
-  assert_output_contains "example.com" 2 # Appears in removal list and cleanup queue
+  assert_output_contains "DNS: Removed 'test-app' from management"
+  assert_output_contains "example.com"
 
   # Check cleanup happened
   assert_file_not_exists "$PLUGIN_DATA_ROOT/test-app"


### PR DESCRIPTION
## Summary
- Simplified post-delete trigger output from 5 verbose lines to 2 concise lines
- Removed redundant messaging that repeated the same information
- Makes the output cleaner and easier to read

## Changes
**Before:**
```
=====> DNS: Cleaning up DNS management for app 'gitea'
-----> DNS: Removing DNS management for domains:
----->   • gitea.deanoftech.com
-----> DNS: App 'gitea' removed from DNS management
-----> DNS: Domains queued for cleanup: gitea.deanoftech.com
-----> DNS: Run 'dokku dns:sync:deletions' to clean up orphaned DNS records
```

**After:**
```
-----> DNS: Removed 'gitea' from management (gitea.deanoftech.com)
       Run 'dokku dns:sync:deletions' to clean up orphaned records
```

## Test plan
- [x] Linting passes
- [ ] CI tests pass (will run automatically)
- [x] Updated test expectations in `tests/dns_triggers.bats`
- [x] Updated example output in `test-output-examples/destroy-trigger.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)